### PR TITLE
docs: make the PostgreSQL migration plan canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# easy-local-rag
+
+> **Repository status:** `main` still contains the old Ollama/Chroma command-line project. The maintained direction is the PostgreSQL/pgvector consolidation in [issue #17](https://github.com/sriharshaguthikonda/easy-local-rag/issues/17). Do not merge the experimental GUI branches wholesale.
+
+Canonical planning documents:
+
+- [PostgreSQL migration sequence](docs/plans/README.md)
+- [Public branch and PR inventory](docs/plans/branch-inventory.md)
+- [Issue #2–#27 disposition map](docs/plans/issue-disposition.md)
+
+The legacy upstream instructions are retained below for reference while migration and export tooling are built.
+
+---
+
 # SuperEasy 100% Local RAG with Ollama + Email RAG
 
 ### YouTube Tutorials

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,70 @@
+# Canonical PostgreSQL migration plan
+
+This directory is the maintained plan for [issue #17](https://github.com/sriharshaguthikonda/easy-local-rag/issues/17). GitHub issues track work and discussion; these files hold the sequencing and architectural decisions. When an old issue conflicts with this plan, update the issue or mark it superseded rather than reviving an experimental implementation.
+
+## Target boundary
+
+`easy-local-rag` will own document adapters, deterministic parsing and chunking, Chroma audit/export tools, retrieval evaluation fixtures, and a thin command-line client.
+
+The `.memory` repository will own the PostgreSQL/pgvector evidence store and shared retrieval boundary. Durable memories and imported evidence remain separate domains. Raw document chunks must not be inserted into durable-memory tables or injected into every prompt.
+
+## Execution order
+
+### 0. Contain and freeze
+
+1. Complete credential rotation and history remediation in [#2](https://github.com/sriharshaguthikonda/easy-local-rag/issues/2). Never publish secret values in reports or issue comments.
+2. Treat every non-default branch as read-only salvage material until [#18](https://github.com/sriharshaguthikonda/easy-local-rag/issues/18) records its SHA, risks, useful ideas, and disposition.
+3. Do not merge PR #1 or either GUI branch wholesale.
+
+### 1. Preserve the current evidence
+
+1. Finish the public and local branch inventory in [#18](https://github.com/sriharshaguthikonda/easy-local-rag/issues/18).
+2. Build the read-only Chroma audit and deterministic export tool in [#19](https://github.com/sriharshaguthikonda/easy-local-rag/issues/19).
+3. Freeze a named Chroma snapshot and record checksums before any migration write.
+
+### 2. Define data contracts
+
+1. Implement the PostgreSQL evidence/source boundary in `.memory` issue #4.
+2. Define deterministic discovery, fingerprinting, parsing, chunking, metadata, embedding provenance, and reconciliation in [#20](https://github.com/sriharshaguthikonda/easy-local-rag/issues/20).
+3. Require stable source IDs, chunk IDs, content hashes, parser/chunker versions, and idempotent imports.
+
+### 3. Prove retrieval before changing clients
+
+1. Implement independent lexical, vector, and metadata candidate retrieval in `.memory` issue #5.
+2. Build Chroma-to-PostgreSQL parity tests in [#23](https://github.com/sriharshaguthikonda/easy-local-rag/issues/23).
+3. Do not call a vector-first rerank "hybrid retrieval"; lexical and vector searches must form independent candidate sets before fusion.
+
+### 4. Move the useful interface
+
+1. Refactor the old command-line workflow into a thin client in [#21](https://github.com/sriharshaguthikonda/easy-local-rag/issues/21).
+2. Add explicit offline-search, local-chat, and cloud-chat provider modes in [#22](https://github.com/sriharshaguthikonda/easy-local-rag/issues/22).
+3. Add structured evidence-grounding, citation validation, and abstention in [#27](https://github.com/sriharshaguthikonda/easy-local-rag/issues/27).
+
+### 5. Cut over, then clean up
+
+1. Use the dual-run and rollback gates in [#25](https://github.com/sriharshaguthikonda/easy-local-rag/issues/25).
+2. Keep Chroma read-only until counts, hashes, provenance, retrieval quality, and rollback have passed.
+3. Rebuild a thin GUI only after the shared contracts are stable, as described in [#24](https://github.com/sriharshaguthikonda/easy-local-rag/issues/24).
+4. Perform history, generated-file, dependency, and layout cleanup last in [#26](https://github.com/sriharshaguthikonda/easy-local-rag/issues/26).
+
+## Stop conditions
+
+Stop the migration or merge when any of these occurs:
+
+- a credential is found and has not been revoked or rotated;
+- an operation would modify the source Chroma database;
+- export/import counts or content hashes cannot be reconciled;
+- embedding model or chunking provenance is unknown and treated as known;
+- lexical retrieval is derived only from vector candidates;
+- evidence IDs or citations cannot be resolved to the exact context sent to the model;
+- a client silently falls back from local to cloud;
+- a branch, database, or rollback copy would be deleted without an immutable recorded reference.
+
+## Supporting records
+
+- [Public branch and PR inventory](branch-inventory.md)
+- [Issue #2–#27 disposition map](issue-disposition.md)
+
+## Immediate bounded work
+
+The first bounded issue resolution is to close [#14](https://github.com/sriharshaguthikonda/easy-local-rag/issues/14) as superseded by #27. Issue #27 deliberately replaces prose-only `[N]` parsing with a structured answer contract, citation validation, and abstention.

--- a/docs/plans/branch-inventory.md
+++ b/docs/plans/branch-inventory.md
@@ -1,0 +1,67 @@
+# Public branch and PR inventory
+
+Snapshot date: 2026-07-18. This is the public GitHub inventory required by issue #18. It intentionally omits credential values and private corpus content. Local-only refs still require a local `git show-ref`, secret scan, and comparison before #18 can close.
+
+## `main`
+
+- Tip: `3e9e864a73137190dd202bdf4827e7a86f31aa84`
+- Role: old upstream-derived CLI and email RAG code; this is the current default branch, not the advanced GUI implementation.
+- Current problem: README and layout still describe the old Ollama/Chroma workflow and do not represent the PostgreSQL/pgvector target.
+- Disposition: retain as the migration base. Add new PostgreSQL work in focused branches; do not replace it with an experimental branch merge.
+
+## `BM25-hyb-kkro-tkn-lmt-synms-mon-chngs-streamlit-chromadb-docs`
+
+- Tip: `ed662570fcd50beb32fc6535bcbd421465f7f881`
+- Relation to `main`: 21 commits ahead, 0 behind.
+- Main additions: several PyQt modules, `rag_gui.py`, `streamlit_app.py`, a large Chroma/Groq/Ollama application module, direct-search and context helpers, file monitoring, semantic chunking, Chroma utilities, TTS code, and GUI tests.
+- Executable/client candidates: `rag_gui.py`, `streamlit_app.py`, `groq_lama_chromadb_RAG_ETTS.py`, the monitor batch file, and ingestion/query utility scripts.
+- Database assumptions: direct ChromaDB access from clients and workers; multiple hard-coded or historical collection names, including `html_chunks_temp` and `html_chunks_text_in_documents`; no shared PostgreSQL service boundary.
+- Provider assumptions: Ollama plus optional/embedded Groq paths, Google TTS and speech-recognition code. Local and cloud behaviour is mixed rather than expressed as explicit modes.
+- Useful salvage:
+  - background worker and progress/error patterns;
+  - streaming result presentation;
+  - search-only interaction;
+  - source/context panes and score display;
+  - database status/reconnect ideas;
+  - deterministic chunk-ID and file-change concepts;
+  - tests that can be converted into contract or regression fixtures.
+- Known broken or unsafe areas:
+  - legacy retrieval defects tracked by #5–#14;
+  - BM25 is derived from vector candidates rather than an independent corpus search (#10);
+  - collection access and provider logic are mixed into clients;
+  - personal Windows paths and runtime downloads occur at import/startup;
+  - broad exception handling hides retrieval failures;
+  - generated `__pycache__`, `.pyc`, logs, caches and browser assets are committed.
+- Disposition: **archive and mine selectively**. Do not merge wholesale. Port only behaviour that has a destination contract and tests under #20–#24 and #27.
+
+## `codex/add-qtpy-gui-for-groq_lama_chromadb_rag_etts.py`
+
+- Tip: `8cb08091347ee41e7c8dac1c04d02a8e5d2eed2b`
+- Relation to `main`: 16 commits ahead, 0 behind.
+- Relation to the current BM25 branch: diverged; 1 commit ahead and 6 commits behind, with merge base `b293135ff91befb0c27d9725b5e7001ff9cc1d0f`.
+- Unique change: a 98-line QtPy wrapper plus one README line and one dependency line.
+- Database/provider assumptions: inherits the older experimental Chroma/Groq application directly rather than using a shared search/chat boundary.
+- Useful salvage: minimal Qt wrapper shape only; the future GUI requirements are already captured by #24.
+- Disposition: **close PR #1 as superseded and archive the SHA**. Do not rebase or merge this branch.
+
+## PR #1 — `Add QtPy GUI for Groq chat`
+
+- State at inspection: open and not mergeable.
+- Base: the experimental BM25 branch, not `main`.
+- Head: the stale/diverged QtPy branch above.
+- Decision: superseded by #17 and #24. Its useful idea is recorded as a future thin-client option; its architecture is not a merge path.
+
+## Closed fixes not present on `main`
+
+Issues #3 and #4 were closed against commits `4686575a55358a0d5bf74447dc5e083e1361f66b` and `07b546964588cf9bce85ec35d9775a58b6266477`. Both commits are descendants of the experimental GUI history and are not part of `main` or either named branch tip inspected above.
+
+Treat these commits as salvage evidence, not as proof that the default branch or future PostgreSQL client is fixed. If file opening or subprocess search is reintroduced, write new tests against the new service/client boundary and port the safety properties rather than cherry-picking the old application files.
+
+## Archive and cleanup rules
+
+1. Rotate/revoke exposed credentials before preserving any public archive ref.
+2. Run a secret scan across all remote, tag, pull-request and local refs; publish only secret types/locations, never values.
+3. Record each local-only branch name and tip SHA in this document before deletion.
+4. Create immutable sanitized archive refs only after the scan.
+5. Close PR #1 after this disposition is linked from GitHub.
+6. Delete no branch until #19 export evidence and #25 rollback gates exist.

--- a/docs/plans/issue-disposition.md
+++ b/docs/plans/issue-disposition.md
@@ -1,0 +1,57 @@
+# Issue #2–#27 disposition map
+
+This map prevents old experimental fixes from driving the PostgreSQL migration. `Keep` means the issue remains a direct deliverable. `Absorb` means its acceptance criteria move into a newer issue. `Supersede` means the old implementation-specific issue should close after the linked replacement is recorded.
+
+| Issue | Disposition | Canonical destination |
+|---|---|---|
+| #2 exposed credentials | **Keep — blocking** | Rotation/revocation, all-ref scan, history remediation; also gates #26. Never publish values. |
+| #3 subprocess injection | Closed on experimental history; **retain as regression requirement** | #21 client boundary and #24 GUI rules. Old commit is not on `main`. |
+| #4 arbitrary file open | Closed on experimental history; **retain as regression requirement** | #21/#24. Any future opener needs allowlisted roots/types and no shell fallback. |
+| #5 prompt injection | **Absorb** | #27 context fencing, untrusted-evidence rules, citation validation and abstention. |
+| #6 missing metadata embedding/MMR crash | **Legacy implementation defect** | #23 must test embeddings as typed retrieval data, not Chroma metadata. Close when the legacy path is frozen. |
+| #7 eager Chroma collection initialisation | **Supersede** | #24 thin client; clients must not initialise storage during import. |
+| #8 hard-coded Windows paths | **Absorb** | #20 explicit source configuration and #26 repository cleanup. |
+| #9 Streamlit state import hijack | **Supersede with security requirement** | #24. Reintroduce conversation import only through a versioned allowlisted schema. |
+| #10 BM25 over vector top-50 | **Supersede** | `.memory` #5 independent lexical/vector retrieval plus #23 parity tests. |
+| #11 embedding-model mismatch | **Absorb** | #20 embedding provenance and #23 mismatch tests. |
+| #12 Streamlit TTS worker deadlock | **Supersede** | #22 provider adapters and #24 thin UI lifecycle. |
+| #13 regex token counter/provider overflow | **Absorb** | #22 provider-specific limits and #27 exact context/truncation reporting. |
+| #14 prose-only inline citations | **Close as superseded** | #27 structured claim/citation contract, validation and abstention. |
+| #15 corrupt append-only `vault.json` | **Absorb** | #20 deterministic packages and atomic/idempotent writes; retire the vault as a production store. |
+| #16 `.env.example`, AGENTS and dependency lock | **Split, keep open for now** | Add safe contributor/env guidance early; finish the supported dependency lock after #21/#22 define the maintained package surface. Broader cleanup belongs to #26. |
+| #17 PostgreSQL/pgvector consolidation | **Epic — canonical** | Sequenced by `docs/plans/README.md`. |
+| #18 branch inventory/archive | **Keep — early** | Complete public and local inventories, sanitised archives, and PR #1 disposition. |
+| #19 read-only Chroma audit/export | **Keep — first implementation** | Must precede schema migration or Chroma cleanup. |
+| #20 deterministic ingestion contracts | **Keep** | Build after the audit format and PostgreSQL evidence boundary are known. |
+| #21 thin CLI client | **Keep** | Start after retrieval contracts exist; the old CLI is the first supported client. |
+| #22 provider abstraction/modes | **Keep** | Follows the thin service boundary; no silent cloud fallback. |
+| #23 retrieval parity/regression | **Keep — migration gate** | Required before PostgreSQL becomes primary. |
+| #24 future thin GUI | **Keep, defer** | No wholesale reuse; begin only after #21, #23 and #27 are stable. |
+| #25 dual-run/rollback/retirement | **Keep — cutover gate** | Chroma remains read-only rollback until all gates pass. |
+| #26 history/layout/generated artefact cleanup | **Keep, last** | Blocked by #2, #18, #19, #23 and #25. |
+| #27 grounded answers/citation validation | **Keep** | Replaces #5 and #14 as the answer-safety contract. |
+
+## Recommended issue sequencing
+
+1. #2 containment work in parallel with the **non-destructive** parts of #18.
+2. #18 public/local inventory, sanitised archive decisions and PR #1 closure.
+3. #19 read-only audit/export.
+4. `.memory` #4 evidence schema/import boundary.
+5. #20 deterministic ingestion and reconciliation.
+6. `.memory` #5 retrieval APIs.
+7. #23 parity/regression suite.
+8. #21 thin CLI.
+9. #22 provider modes and #27 grounded answers.
+10. #25 dual-run/cutover.
+11. #24 optional GUI.
+12. #26 cleanup and retirement.
+
+## Closure policy for legacy issues
+
+Do not patch the experimental GUI merely to close #5–#15. Close an old issue only when one of these is true:
+
+- its fix is part of a supported path and has a regression test;
+- its requirement is explicitly accepted by a newer canonical issue;
+- the affected path is archived and marked unsupported, with the replacement linked.
+
+A commit on a stale or deleted experimental ref is not enough to prove the maintained path is fixed.


### PR DESCRIPTION
## What changed

- add the canonical PostgreSQL/pgvector migration sequence for #17
- record the public branch tips, divergence, salvage targets, unsafe/generated artefacts, and PR #1 disposition for #18
- map issues #2–#27 to keep, absorb, or supersede decisions
- add a prominent README status block linking the plans

## Why

`main` is still the old CLI while the later fixes and GUI work live on divergent experimental history. These documents stop stale implementation-specific issues from becoming the migration plan and make the non-destructive order explicit.

## Validation

- fetched all three new files from the branch and checked their rendered content
- compared the branch to `main`: 4 commits, 4 intended files, no code or secret values changed

Refs #17 and #18. The issue map records #14 as superseded by #27; #14 will be closed separately after this plan is on `main`.