### PR TITLE
fix(#6): read Chroma documents in hybrid retrieval

### DIFF
--- a/streamlit_groq_lama_chromadb_RAG_ETTS.py
+++ b/streamlit_groq_lama_chromadb_RAG_ETTS.py
@@ -679,12 +679,14 @@ def get_relevant_context_hybrid(
         # Extract results with distances
         vector_results = [
             {
+                "document": document,
                 "meta": meta,
                 "embedding": emb,
                 "vector_score": 1.0
                 - dist,  # Convert distance to similarity (assuming normalized)
             }
-            for meta, dist, emb in zip(
+            for document, meta, dist, emb in zip(
+                search_result["documents"][0],
                 search_result["metadatas"][0],
                 search_result["distances"][0],
                 search_result["embeddings"][0],
@@ -708,15 +710,26 @@ def get_relevant_context_hybrid(
             # Use a set to remove duplicates
             keywords = set(keywords)
 
-            for meta in search_result["metadatas"][0]:
+            for document, meta, emb in zip(
+                search_result["documents"][0],
+                search_result["metadatas"][0],
+                search_result["embeddings"][0],
+            ):
                 # Match against both original keywords and their synonyms
                 match_score = sum(
-                    meta["text"].lower().count(keyword)
+                    document.lower().count(keyword)
                     + meta["file_name"].lower().count(keyword)
                     for keyword in keywords
                 )
                 if match_score > 0:
-                    keyword_results.append({"meta": meta, "keyword_score": match_score})
+                    keyword_results.append(
+                        {
+                            "document": document,
+                            "meta": meta,
+                            "embedding": emb,
+                            "keyword_score": match_score,
+                        }
+                    )
 
         # Normalize scores for both vector and keyword results
         max_vector_score = max(
@@ -737,6 +750,7 @@ def get_relevant_context_hybrid(
         for res in vector_results:
             file_name = res["meta"]["file_name"]
             combined_results[file_name] = {
+                "document": res["document"],
                 "meta": res["meta"],
                 "embedding": res["embedding"],
                 "final_score": alpha * res["vector_score"],
@@ -750,6 +764,7 @@ def get_relevant_context_hybrid(
                 )
             else:
                 combined_results[file_name] = {
+                    "document": res["document"],
                     "meta": res["meta"],
                     "embedding": res.get("embedding"),
                     "final_score": beta * res["keyword_score"],
@@ -760,48 +775,48 @@ def get_relevant_context_hybrid(
             combined_results.values(), key=lambda x: x["final_score"], reverse=True
         )
 
-        # Limit results to top_k
-        final_results = [res["meta"] for res in sorted_results[:top_k]]
-
-        # Use MMR to select additional_unique_files
+        # Seed MMR with the top-k results, then add one diverse result at a time.
+        selected_results = sorted_results[:top_k]
         remaining_results = [res for res in sorted_results[top_k:]]
-        selected_additional_files = []
+        for _ in range(additional_unique_files):
+            if not remaining_results:
+                break
 
-        for res in remaining_results:
-            current_embedding = res.get("embedding")
-            if current_embedding is None:
-                res["mmr_score"] = res["final_score"]
-                continue
-            max_similarity = max(
-                [
-                    np.dot(current_embedding, selected["embedding"])
-                    for selected in selected_additional_files
-                    if selected.get("embedding") is not None
-                ],
-                default=0,
-            )
-            mmr_score = (
-                lambda_mmr * res["final_score"] - (1 - lambda_mmr) * max_similarity
-            )
-            res["mmr_score"] = mmr_score
+            best_result = None
+            best_score = None
+            for res in remaining_results:
+                current_embedding = res.get("embedding")
+                max_similarity = max(
+                    [
+                        np.dot(current_embedding, selected["embedding"])
+                        for selected in selected_results
+                        if current_embedding is not None
+                        and selected.get("embedding") is not None
+                    ],
+                    default=0,
+                )
+                mmr_score = (
+                    res["final_score"]
+                    if current_embedding is None
+                    else lambda_mmr * res["final_score"]
+                    - (1 - lambda_mmr) * max_similarity
+                )
+                if best_score is None or mmr_score > best_score:
+                    best_result = res
+                    best_score = mmr_score
 
-        # Sort by MMR score to get the most relevant and diverse results
-        sorted_additional_files = sorted(
-            remaining_results, key=lambda x: x["mmr_score"], reverse=True
-        )
+            selected_results.append(best_result)
+            remaining_results.remove(best_result)
 
-        selected_additional_files = sorted_additional_files[:additional_unique_files]
-
-        # Combine the top_k and the selected additional unique files
-        final_results.extend([res["meta"] for res in selected_additional_files])
+        final_results = [res["meta"] for res in selected_results]
 
         # Prepare relevant context
-        relevant_context = "\n\n".join([res["text"] for res in final_results])
+        relevant_context = "\n\n".join([res["document"] for res in selected_results])
 
         # Start a worker thread to print details of the results
         worker_thread = threading.Thread(
             target=print_relevant_context,
-            args=(final_results,),
+            args=(selected_results,),
             daemon=True,
         )
         worker_thread.start()
@@ -816,10 +831,11 @@ def get_relevant_context_hybrid(
 
 def print_relevant_context(results):
     print("Context Pulled from Documents:\n")
-    for meta in results:
+    for result in results:
+        meta = result["meta"]
         file_name = meta["file_name"]
         modification_time = meta.get("modification_time", "Unknown")
-        text = meta["text"]
+        text = result["document"]
 
         clickable_file_path = urljoin("file:", Path(file_name).as_uri())
 

--- a/tests/test_streamlit_hybrid_embeddings.py
+++ b/tests/test_streamlit_hybrid_embeddings.py
@@ -1,10 +1,77 @@
+import ast
 from pathlib import Path
+from types import SimpleNamespace
 
 
-def test_streamlit_hybrid_queries_embeddings_array():
+class _FakeCollection:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def query(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result
+
+
+class _NoopThread:
+    def __init__(self, **_kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+def test_hybrid_context_uses_documents_and_greedy_mmr_without_metadata_text():
     source = Path("streamlit_groq_lama_chromadb_RAG_ETTS.py").read_text(
         encoding="utf-8"
     )
-    assert 'include=["documents", "metadatas", "distances", "embeddings"]' in source
-    assert '"embedding": emb' in source
-    assert 'res["meta"]["embedding"]' not in source
+    function = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "get_relevant_context_hybrid"
+    )
+
+    metadata = [
+        {"file_name": "a.txt", "modification_time": "1"},
+        {"file_name": "b.txt", "modification_time": "2"},
+        {"file_name": "c.txt", "modification_time": "3"},
+        {"file_name": "d.txt", "modification_time": "4"},
+    ]
+    collection = _FakeCollection(
+        {
+            "documents": [["needle alpha", "needle beta", "needle gamma", "needle delta"]],
+            "metadatas": [metadata],
+            "distances": [[0.0, 0.1, 0.2, 0.3]],
+            "embeddings": [[[1, 0], [1, 0], [0, 1], [0, 1]]],
+        }
+    )
+    namespace = {
+        "rewrite_input_and_generate_synonyms": lambda text: (text, {}),
+        "ollama": SimpleNamespace(
+            embeddings=lambda **_kwargs: {"embedding": [1, 0]}
+        ),
+        "model": "test-model",
+        "collection": collection,
+        "non_keywords": set(),
+        "np": SimpleNamespace(dot=lambda left, right: sum(a * b for a, b in zip(left, right))),
+        "threading": SimpleNamespace(Thread=_NoopThread),
+        "print_relevant_context": lambda _results: None,
+    }
+    exec(compile(ast.Module(body=[function], type_ignores=[]), "backend", "exec"), namespace)
+
+    result = namespace["get_relevant_context_hybrid"](
+        "needle", top_k=1, additional_unique_files=2, keyword_match=True
+    )
+
+    assert collection.calls == [
+        {
+            "query_embeddings": [[1, 0]],
+            "n_results": 50,
+            "include": ["documents", "metadatas", "distances", "embeddings"],
+        }
+    ]
+    assert result != ("Answer this yourself!", [])
+    context, returned_metadata = result
+    assert context == "needle alpha\n\nneedle gamma\n\nneedle beta"
+    assert returned_metadata == [metadata[0], metadata[2], metadata[1]]


### PR DESCRIPTION
## Summary

- read chunk text from Chroma's `documents` array instead of metadata
- preserve the existing `(context, metadata)` return contract
- make additional-file MMR selection greedy and incremental after the top-K seed
- add an AST-isolated functional regression covering separate documents/embeddings arrays

Addresses #6. No dependency or Chroma schema change.

## Verification

- `python -m pytest tests/test_streamlit_hybrid_embeddings.py -q -p no:cacheprovider` — 1 passed
- `python -m py_compile streamlit_app.py rag_gui.py GUI_direct_search.py streamlit_groq_lama_chromadb_RAG_ETTS.py` — passed
- full `python -m pytest tests -q -p no:cacheprovider` — existing collection blockers: PyQt5 is not installed for `test_gui_settings.py` and `test_rag_gui_comprehensive.py`
- remaining non-GUI suite — 27 passed, 1 existing failure in the closed #14 citation source-string assertion

## Review

Independent read-only review: no Critical or Important findings; ready to merge.