### PR TITLE
fix: validate conversation imports (#9)

### DIFF
--- a/conversation_import.py
+++ b/conversation_import.py
@@ -49,6 +49,15 @@ def _parse_integer(value: str) -> int:
     return -result if negative else result
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ConversationImportError("Import contains duplicate object keys.")
+        result[key] = value
+    return result
+
+
 def _validate_json_depth(payload: object) -> None:
     stack: list[tuple[object, int]] = [(payload, 1)]
     while stack:
@@ -92,6 +101,7 @@ def sanitize_conversation_import(raw: bytes) -> tuple[dict[str, object], list[st
             parse_constant=_reject_non_finite,
             parse_float=_parse_finite_float,
             parse_int=_parse_integer,
+            object_pairs_hook=_reject_duplicate_keys,
         )
     except RecursionError as error:
         raise ConversationImportError("Import nesting exceeds 32 containers.") from error

--- a/conversation_import.py
+++ b/conversation_import.py
@@ -1,89 +1,188 @@
+import json
+import math
+from collections.abc import Callable, MutableMapping
 from typing import Any
 
-
-ALLOWED_KEYS = {"history", "tags", "favorites"}
-ALLOWED_ROLES = {"system", "user", "assistant"}
-MAX_MESSAGE_LENGTH = 20000
-
-
-def validate_message(message: Any) -> tuple[bool, str]:
-    if not isinstance(message, dict):
-        return False, "Message is not an object."
-
-    role = message.get("role")
-    content = message.get("content")
-
-    if role not in ALLOWED_ROLES:
-        return False, f"Invalid role: {role!r}."
-    if not isinstance(content, str):
-        return False, "Message content must be a string."
-    if len(content) > MAX_MESSAGE_LENGTH:
-        return False, "Message content exceeds size limit."
-
-    return True, ""
+MAX_IMPORT_BYTES = 8 * 1024 * 1024
+MAX_INTEGER_DIGITS = 4_096
+MAX_JSON_DEPTH = 32
+MAX_HISTORY_ENTRIES = 1_000
+MAX_MESSAGE_BYTES = 64 * 1024
+MAX_TAGS = 100
+MAX_FAVORITES = 100
+MAX_TEXT_CHARS = 256
+_TOP_LEVEL_KEYS = {"history", "tags", "favorites", "sources"}
+_ROLES = {"system", "user", "assistant"}
 
 
-def sanitize_conversation_import(data: Any) -> tuple[dict[str, Any], list[str]]:
-    warnings: list[str] = []
-    safe_data: dict[str, Any] = {}
+class ConversationImportError(ValueError):
+    """Raised when an uploaded conversation violates the fixed import contract."""
 
-    if not isinstance(data, dict):
-        return {}, ["Import payload must be a JSON object."]
 
-    unknown_keys = sorted(set(data.keys()) - ALLOWED_KEYS)
-    if unknown_keys:
-        warnings.append(f"Ignored unsupported keys: {', '.join(unknown_keys)}")
+def _text(value: Any, message: str) -> str:
+    if not isinstance(value, str) or len(value) > MAX_TEXT_CHARS:
+        raise ConversationImportError(message)
+    return value
 
-    history = data.get("history", [])
-    if history is not None:
-        if isinstance(history, list):
-            valid_history = []
-            for idx, message in enumerate(history):
-                ok, reason = validate_message(message)
-                if ok:
-                    valid_history.append(
-                        {"role": message["role"], "content": message["content"]}
-                    )
+
+def _reject_non_finite(value: str) -> None:
+    raise ConversationImportError("Import contains a non-finite number.")
+
+
+def _parse_finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ConversationImportError("Import contains a non-finite number.")
+    return parsed
+
+
+def _parse_integer(value: str) -> int:
+    negative = value.startswith("-")
+    digits = value[1:] if negative else value
+    if not digits or len(digits) > MAX_INTEGER_DIGITS:
+        raise ConversationImportError("Import integer exceeds 4096 digits.")
+    result = 0
+    for digit in digits:
+        if digit < "0" or digit > "9":
+            raise ConversationImportError("Import integer exceeds 4096 digits.")
+        result = result * 10 + ord(digit) - ord("0")
+    return -result if negative else result
+
+
+def _validate_json_depth(payload: object) -> None:
+    stack: list[tuple[object, int]] = [(payload, 1)]
+    while stack:
+        value, depth = stack.pop()
+        if depth > MAX_JSON_DEPTH:
+            raise ConversationImportError("Import nesting exceeds 32 containers.")
+        if isinstance(value, dict):
+            stack.extend((child, depth + 1) for child in value.values() if isinstance(child, (dict, list)))
+        elif isinstance(value, list):
+            stack.extend((child, depth + 1) for child in value if isinstance(child, (dict, list)))
+
+
+def _validate_strings(payload: object) -> None:
+    stack = [payload]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, str):
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ConversationImportError("Import strings must be valid UTF-8.") from error
+        elif isinstance(value, dict):
+            for key, child in value.items():
+                try:
+                    key.encode("utf-8")
+                except UnicodeEncodeError as error:
+                    raise ConversationImportError("Import strings must be valid UTF-8.") from error
+                stack.append(child)
+        elif isinstance(value, list):
+            stack.extend(value)
+
+
+def sanitize_conversation_import(raw: bytes) -> tuple[dict[str, object], list[str]]:
+    if not isinstance(raw, bytes):
+        raise ConversationImportError("Import must be raw bytes.")
+    if len(raw) > MAX_IMPORT_BYTES:
+        raise ConversationImportError("Import exceeds 8 MiB limit.")
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"),
+            parse_constant=_reject_non_finite,
+            parse_float=_parse_finite_float,
+            parse_int=_parse_integer,
+        )
+    except RecursionError as error:
+        raise ConversationImportError("Import nesting exceeds 32 containers.") from error
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ConversationImportError("Import must be UTF-8 JSON bytes.") from error
+    if not isinstance(payload, dict):
+        raise ConversationImportError("Import root must be a JSON object.")
+    _validate_json_depth(payload)
+    _validate_strings(payload)
+    if any(not isinstance(key, str) or key.startswith("_") or key not in _TOP_LEVEL_KEYS for key in payload):
+        raise ConversationImportError("Unsupported import key.")
+    safe: dict[str, object] = {}
+    if "history" in payload:
+        history = payload["history"]
+        if not isinstance(history, list):
+            raise ConversationImportError("History must be a list.")
+        if len(history) > MAX_HISTORY_ENTRIES:
+            raise ConversationImportError("History exceeds 1000 entries.")
+        result: list[dict[str, str]] = []
+        for message in history:
+            if not isinstance(message, dict) or set(message) != {"role", "content"}:
+                raise ConversationImportError("Message must contain exactly role and content.")
+            role, content = message["role"], message["content"]
+            if not isinstance(role, str) or role not in _ROLES:
+                raise ConversationImportError("Message role is invalid.")
+            if not isinstance(content, str):
+                raise ConversationImportError("Message content must be a string.")
+            if len(content.encode("utf-8")) > MAX_MESSAGE_BYTES:
+                raise ConversationImportError("Message content exceeds 64 KiB.")
+            result.append({"role": role, "content": content})
+        safe["history"] = result
+    if "tags" in payload:
+        tags = payload["tags"]
+        if not isinstance(tags, dict):
+            raise ConversationImportError("Tags must be an object.")
+        if len(tags) > MAX_TAGS:
+            raise ConversationImportError("Tags exceed 100 keys.")
+        total_values = 0
+        result_tags: dict[str, list[str]] = {}
+        for key, values in tags.items():
+            key = _text(key, "Tag text exceeds 256 characters.")
+            if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+                raise ConversationImportError("Tag values must be string lists.")
+            total_values += len(values)
+            if total_values > MAX_TAGS:
+                raise ConversationImportError("Tags exceed 100 total values.")
+            result_tags[key] = [_text(value, "Tag text exceeds 256 characters.") for value in values]
+        safe["tags"] = result_tags
+    if "favorites" in payload:
+        favorites = payload["favorites"]
+        if not isinstance(favorites, list):
+            raise ConversationImportError("Favorites must be a list.")
+        if len(favorites) > MAX_FAVORITES:
+            raise ConversationImportError("Favorites exceed 100 entries.")
+        result_favorites: list[dict[str, str | int | float | bool | None]] = []
+        for favorite in favorites:
+            if not isinstance(favorite, dict):
+                raise ConversationImportError("Favorite must be an object.")
+            clean: dict[str, str | int | float | bool | None] = {}
+            for key, value in favorite.items():
+                key = _text(key, "Favorite text exceeds 256 characters.")
+                if isinstance(value, str):
+                    clean[key] = _text(value, "Favorite text exceeds 256 characters.")
+                elif value is None or isinstance(value, bool) or isinstance(value, int):
+                    clean[key] = value
+                elif isinstance(value, float) and math.isfinite(value):
+                    clean[key] = value
                 else:
-                    warnings.append(f"Ignored history[{idx}]: {reason}")
-            safe_data["history"] = valid_history
-        else:
-            warnings.append("Ignored history: expected a list.")
+                    raise ConversationImportError("Favorite value must be a finite scalar.")
+            result_favorites.append(clean)
+        safe["favorites"] = result_favorites
+    return safe, ["Ignored legacy export-only key: sources."] if "sources" in payload else []
 
-    tags = data.get("tags", {})
-    if tags is not None:
-        if isinstance(tags, dict):
-            safe_tags: dict[str, Any] = {}
-            for key, value in tags.items():
-                if not isinstance(key, str):
-                    warnings.append("Ignored a tag key that is not a string.")
-                    continue
-                if isinstance(value, (str, int, float, bool)) or value is None:
-                    safe_tags[key] = value
-                elif isinstance(value, list) and all(
-                    isinstance(item, (str, int, float, bool)) or item is None
-                    for item in value
-                ):
-                    safe_tags[key] = value
-                else:
-                    warnings.append(f"Ignored tag '{key}': unsupported value type.")
-            safe_data["tags"] = safe_tags
-        else:
-            warnings.append("Ignored tags: expected an object.")
 
-    favorites = data.get("favorites", [])
-    if favorites is not None:
-        if isinstance(favorites, list):
-            safe_favorites = []
-            for idx, value in enumerate(favorites):
-                if isinstance(value, (str, int, float, bool)) or value is None:
-                    safe_favorites.append(value)
-                elif isinstance(value, dict):
-                    safe_favorites.append(value)
-                else:
-                    warnings.append(f"Ignored favorites[{idx}]: unsupported type.")
-            safe_data["favorites"] = safe_favorites
-        else:
-            warnings.append("Ignored favorites: expected a list.")
+def apply_conversation_import(session_state: MutableMapping[str, object], raw: bytes) -> list[str]:
+    safe_data, warnings = sanitize_conversation_import(raw)
+    if "history" in safe_data:
+        session_state["conversation_history"] = safe_data["history"]
+    if "tags" in safe_data:
+        session_state["tags"] = safe_data["tags"]
+    if "favorites" in safe_data:
+        session_state["favorite_responses"] = safe_data["favorites"]
+    return warnings
 
-    return safe_data, warnings
+
+def apply_uploaded_conversation(uploaded_file: Any, session_state: MutableMapping[str, object], show_warning: Callable[[str], None], show_success: Callable[[str], None]) -> None:
+    try:
+        warnings = apply_conversation_import(session_state, uploaded_file.getvalue())
+    except ConversationImportError as error:
+        show_warning(f"Conversation import rejected: {error}")
+        return
+    for warning in warnings:
+        show_warning(warning)
+    show_success("Conversation import complete.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -69,7 +69,7 @@ import tempfile
 from wordcloud import WordCloud
 import matplotlib.pyplot as plt
 
-from conversation_import import sanitize_conversation_import
+from conversation_import import apply_uploaded_conversation
 from rag_prompting import CONTEXT_GUARD, build_guarded_context_block
 from token_budget import trim_messages_to_budget
 
@@ -621,24 +621,7 @@ def main():
 
         uploaded_file = st.file_uploader("Import Conversation")
         if uploaded_file:
-            try:
-                imported_data = json.loads(uploaded_file.read())
-                safe_data, import_warnings = sanitize_conversation_import(imported_data)
-
-                if "history" in safe_data:
-                    st.session_state.conversation_history = safe_data["history"]
-                if "tags" in safe_data:
-                    st.session_state.tags = safe_data["tags"]
-                if "favorites" in safe_data:
-                    st.session_state.favorite_responses = safe_data["favorites"]
-
-                for warning in import_warnings:
-                    st.warning(warning)
-
-                if not import_warnings:
-                    st.success("Conversation import complete.")
-            except Exception as e:
-                st.error(f"Import failed: {e}")
+            apply_uploaded_conversation(uploaded_file, st.session_state, st.warning, st.success)
 
     # Auto-focus script
     st.markdown(

--- a/tests/test_conversation_import.py
+++ b/tests/test_conversation_import.py
@@ -264,6 +264,26 @@ def test_uploaded_lone_surrogates_make_zero_writes(template: bytes, escaped: byt
     assert successes == []
 
 
+@pytest.mark.parametrize("overwritten", [
+    b'"\\ud800"',
+    b'"\\udc00"',
+    b"[" * MAX_JSON_DEPTH + b"null" + b"]" * MAX_JSON_DEPTH,
+])
+def test_uploaded_duplicate_sources_make_zero_writes(overwritten: bytes) -> None:
+    class UploadedFile:
+        def getvalue(self) -> bytes:
+            return b'{"sources":' + overwritten + b',"sources":null}'
+
+    state = sentinel_state()
+    state.assignments.clear()
+    warnings: list[str] = []
+    successes: list[str] = []
+    apply_uploaded_conversation(UploadedFile(), state, warnings.append, successes.append)
+    assert state.assignments == []
+    assert warnings == ["Conversation import rejected: Import contains duplicate object keys."]
+    assert successes == []
+
+
 def test_json_depth_limit_and_parser_recursion_reject() -> None:
     nested: object = None
     for _ in range(MAX_JSON_DEPTH - 1):

--- a/tests/test_conversation_import.py
+++ b/tests/test_conversation_import.py
@@ -1,42 +1,329 @@
-from conversation_import import sanitize_conversation_import, validate_message
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from conversation_import import (
+    MAX_FAVORITES, MAX_HISTORY_ENTRIES, MAX_IMPORT_BYTES, MAX_INTEGER_DIGITS, MAX_JSON_DEPTH,
+    MAX_MESSAGE_BYTES, MAX_TAGS, MAX_TEXT_CHARS, ConversationImportError,
+    apply_conversation_import, apply_uploaded_conversation,
+    sanitize_conversation_import,
+)
 
 
-def test_validate_message_accepts_valid_message():
-    ok, reason = validate_message({"role": "user", "content": "hello"})
-    assert ok is True
-    assert reason == ""
+class RecordingState(dict[str, object]):
+    def __init__(self, initial: dict[str, object]) -> None:
+        super().__init__(initial)
+        self.assignments: list[str] = []
+
+    def __setitem__(self, key: str, value: object) -> None:
+        self.assignments.append(key)
+        super().__setitem__(key, value)
 
 
-def test_validate_message_rejects_invalid_role():
-    ok, reason = validate_message({"role": "tool", "content": "x"})
-    assert ok is False
-    assert "Invalid role" in reason
+def sentinel_state() -> RecordingState:
+    return RecordingState({
+        "collection": object(), "chroma_client": object(),
+        "current_sources": object(), "source_filters": object(),
+        "tts_queue": object(), "tts_worker": object(),
+        "conversation_history": ["old-history"], "tags": {"old": ["tag"]},
+        "favorite_responses": [{"old": "favorite"}],
+    })
 
 
-def test_sanitize_conversation_import_ignores_unsafe_keys():
-    payload = {
+def raw(payload: object) -> bytes:
+    return json.dumps(payload, allow_nan=False).encode("utf-8")
+
+
+def valid_payload() -> dict[str, object]:
+    return {
         "history": [{"role": "user", "content": "hello"}],
-        "collection": "owned",
-        "tts_worker": {"bad": True},
+        "tags": {"notes.md": ["keep"]},
+        "favorites": [{"file_name": "notes.md", "score": 0.9}],
     }
-    safe_data, warnings = sanitize_conversation_import(payload)
-
-    assert "history" in safe_data
-    assert safe_data["history"] == [{"role": "user", "content": "hello"}]
-    assert any("Ignored unsupported keys" in message for message in warnings)
-    assert "collection" not in safe_data
-    assert "tts_worker" not in safe_data
 
 
-def test_sanitize_conversation_import_filters_bad_history():
-    payload = {
-        "history": [
-            {"role": "assistant", "content": "ok"},
-            {"role": "tool", "content": "bad"},
-            {"role": "user", "content": 123},
-        ]
-    }
-    safe_data, warnings = sanitize_conversation_import(payload)
+def test_valid_import_assigns_only_conversation_fields_and_preserves_runtime_sentinels() -> None:
+    state = sentinel_state()
+    collection, chroma_client = state["collection"], state["chroma_client"]
+    current_sources, source_filters = state["current_sources"], state["source_filters"]
+    tts_queue, tts_worker = state["tts_queue"], state["tts_worker"]
+    state.assignments.clear()
+    warnings = apply_conversation_import(state, raw(valid_payload()))
+    assert warnings == []
+    assert state.assignments == ["conversation_history", "tags", "favorite_responses"]
+    assert state["collection"] is collection
+    assert state["chroma_client"] is chroma_client
+    assert state["current_sources"] is current_sources
+    assert state["source_filters"] is source_filters
+    assert state["tts_queue"] is tts_queue
+    assert state["tts_worker"] is tts_worker
 
-    assert safe_data["history"] == [{"role": "assistant", "content": "ok"}]
-    assert len(warnings) >= 2
+
+def test_legacy_sources_are_warned_and_never_applied() -> None:
+    payload = valid_payload() | {"sources": [{"file_path": "ignored"}]}
+    safe, warnings = sanitize_conversation_import(raw(payload))
+    assert "sources" not in safe
+    assert warnings == ["Ignored legacy export-only key: sources."]
+
+
+@pytest.mark.parametrize(("payload", "message"), [
+    ({"current_sources": [{"file_path": "crafted"}]}, "Unsupported import key."),
+    ({"collection": "crafted"}, "Unsupported import key."),
+    ({"chroma_client": "crafted"}, "Unsupported import key."),
+    ({"source_filters": "crafted"}, "Unsupported import key."),
+    ({"tts_queue": "crafted"}, "Unsupported import key."),
+    ({"tts_worker": "crafted"}, "Unsupported import key."),
+    ({"_runtime": "crafted"}, "Unsupported import key."),
+    ({"unexpected": "crafted"}, "Unsupported import key."),
+    ({"history": [{"role": "tool", "content": "crafted"}]}, "Message role is invalid."),
+    ({"history": [{"role": "user", "content": 1}]}, "Message content must be a string."),
+    ({"history": [{"role": "user", "content": "x", "extra": "x"}]}, "Message must contain exactly role and content."),
+    ({"tags": {"notes.md": ["ok", 1]}}, "Tag values must be string lists."),
+    ({"favorites": [{"file_name": {"nested": "object"}}]}, "Favorite value must be a finite scalar."),
+])
+def test_rejected_payload_performs_zero_assignments(payload: dict[str, object], message: str) -> None:
+    state = sentinel_state()
+    before = dict(state)
+    state.assignments.clear()
+    with pytest.raises(ConversationImportError, match="^" + re.escape(message) + "$"):
+        apply_conversation_import(state, raw(payload))
+    assert state.assignments == []
+    assert dict(state) == before
+
+
+def test_exact_raw_8_mib_passes() -> None:
+    raw_exact = b'{"sources":null}' + b" " * (MAX_IMPORT_BYTES - len(b'{"sources":null}'))
+    assert len(raw_exact) == MAX_IMPORT_BYTES
+    assert sanitize_conversation_import(raw_exact) == ({}, ["Ignored legacy export-only key: sources."])
+
+
+def test_exact_message_64_kib_passes() -> None:
+    content = "é" * (MAX_MESSAGE_BYTES // len("é".encode("utf-8")))
+    assert len(content.encode("utf-8")) == MAX_MESSAGE_BYTES
+    safe, warnings = sanitize_conversation_import(raw({"history": [{"role": "user", "content": content}]}))
+    assert warnings == []
+    assert safe["history"][0]["content"] == content
+
+
+def test_exact_other_limits_pass() -> None:
+    tags = {f"k{i}": ["v"] for i in range(MAX_TAGS)}
+    favorites = [{"file_name": "x"} for _ in range(MAX_FAVORITES)]
+    history = [{"role": "user", "content": ""} for _ in range(MAX_HISTORY_ENTRIES)]
+    safe, warnings = sanitize_conversation_import(raw({"history": history, "tags": tags, "favorites": favorites}))
+    assert warnings == []
+    assert len(safe["history"]) == MAX_HISTORY_ENTRIES
+    assert len(safe["tags"]) == MAX_TAGS
+    assert sum(map(len, safe["tags"].values())) == MAX_TAGS
+    assert len(safe["favorites"]) == MAX_FAVORITES
+    assert sanitize_conversation_import(raw({"tags": {"k" * MAX_TEXT_CHARS: ["v" * MAX_TEXT_CHARS]}, "favorites": [{"k" * MAX_TEXT_CHARS: "v" * MAX_TEXT_CHARS}]}))[1] == []
+
+
+def test_non_bytes_rejects() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import must be raw bytes.") + "$"):
+        sanitize_conversation_import("{}")  # type: ignore[arg-type]
+
+
+def test_raw_bytes_over_limit_rejects_before_decode() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import exceeds 8 MiB limit.") + "$"):
+        sanitize_conversation_import(b"\xff" * (MAX_IMPORT_BYTES + 1))
+
+
+def test_history_entry_over_limit_rejects() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("History exceeds 1000 entries.") + "$"):
+        sanitize_conversation_import(raw({"history": [{"role": "user", "content": ""}] * (MAX_HISTORY_ENTRIES + 1)}))
+
+
+def test_message_utf8_byte_over_limit_rejects() -> None:
+    content = "é" * (MAX_MESSAGE_BYTES // len("é".encode("utf-8")) + 1)
+    assert len(content) < MAX_MESSAGE_BYTES
+    assert len(content.encode("utf-8")) > MAX_MESSAGE_BYTES
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Message content exceeds 64 KiB.") + "$"):
+        sanitize_conversation_import(raw({"history": [{"role": "user", "content": content}]}))
+
+
+def test_tag_count_and_value_count_over_limits_reject() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Tags exceed 100 keys.") + "$"):
+        sanitize_conversation_import(raw({"tags": {str(i): [] for i in range(MAX_TAGS + 1)}}))
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Tags exceed 100 total values.") + "$"):
+        sanitize_conversation_import(raw({"tags": {"k": ["x"] * (MAX_TAGS + 1)}}))
+
+
+def test_favorite_count_over_limit_rejects() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Favorites exceed 100 entries.") + "$"):
+        sanitize_conversation_import(raw({"favorites": [{}] * (MAX_FAVORITES + 1)}))
+
+
+def test_tag_and_favorite_text_over_limit_reject() -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Tag text exceeds 256 characters.") + "$"):
+        sanitize_conversation_import(raw({"tags": {"x" * (MAX_TEXT_CHARS + 1): []}}))
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Favorite text exceeds 256 characters.") + "$"):
+        sanitize_conversation_import(raw({"favorites": [{"x" * (MAX_TEXT_CHARS + 1): "ok"}]}))
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Tag text exceeds 256 characters.") + "$"):
+        sanitize_conversation_import(raw({"tags": {"ok": ["x" * (MAX_TEXT_CHARS + 1)]}}))
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Favorite text exceeds 256 characters.") + "$"):
+        sanitize_conversation_import(raw({"favorites": [{"ok": "x" * (MAX_TEXT_CHARS + 1)}]}))
+
+
+@pytest.mark.parametrize("raw_bytes, message", [
+    (b"\xff", "Import must be UTF-8 JSON bytes."),
+    (b"{", "Import must be UTF-8 JSON bytes."),
+    (b"[]", "Import root must be a JSON object."),
+])
+def test_invalid_utf8_malformed_json_and_array_root_reject(raw_bytes: bytes, message: str) -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape(message) + "$"):
+        sanitize_conversation_import(raw_bytes)
+
+
+@pytest.mark.parametrize("raw_bytes", [
+    b'{"sources":NaN}', b'{"sources":Infinity}', b'{"sources":-Infinity}',
+    b'{"sources":1e999}', b'{"favorites":[{"score":1e999}]}',
+])
+def test_non_finite_json_numbers_reject_even_in_ignored_sources(raw_bytes: bytes) -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import contains a non-finite number.") + "$"):
+        sanitize_conversation_import(raw_bytes)
+
+
+def test_finite_favorite_float_passes() -> None:
+    safe, warnings = sanitize_conversation_import(b'{"favorites":[{"score":1.25}]}')
+    assert warnings == []
+    assert safe == {"favorites": [{"score": 1.25}]}
+
+
+@pytest.mark.parametrize(("sign", "negative"), [(b"", False), (b"-", True)])
+def test_exact_integer_digit_limit_passes(sign: bytes, negative: bool) -> None:
+    raw_bytes = b'{"favorites":[{"score":' + sign + b"9" * MAX_INTEGER_DIGITS + b'}]}'
+    safe, warnings = sanitize_conversation_import(raw_bytes)
+    assert warnings == []
+    score = safe["favorites"][0]["score"]
+    assert isinstance(score, int) and (score < 0) is negative and abs(score).bit_length() > 0
+
+
+@pytest.mark.parametrize("raw_bytes", [
+    b'{"sources":' + b"9" * (MAX_INTEGER_DIGITS + 1) + b'}',
+    b'{"favorites":[{"score":' + b"9" * (MAX_INTEGER_DIGITS + 1) + b'}]}',
+    b'{"favorites":[{"score":-' + b"9" * (MAX_INTEGER_DIGITS + 1) + b'}]}',
+])
+def test_over_cap_integer_rejects_everywhere(raw_bytes: bytes) -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import integer exceeds 4096 digits.") + "$"):
+        sanitize_conversation_import(raw_bytes)
+
+
+def test_uploaded_handler_over_cap_integer_makes_zero_writes() -> None:
+    class UploadedFile:
+        def getvalue(self) -> bytes:
+            return b'{"favorites":[{"score":' + b"9" * (MAX_INTEGER_DIGITS + 1) + b'}]}'
+
+    state = sentinel_state()
+    state.assignments.clear()
+    warnings: list[str] = []
+    successes: list[str] = []
+    apply_uploaded_conversation(UploadedFile(), state, warnings.append, successes.append)
+    assert state.assignments == []
+    assert warnings == ["Conversation import rejected: Import integer exceeds 4096 digits."]
+    assert successes == []
+
+
+@pytest.mark.parametrize("template", [
+    b'{"history":[{"role":"user","content":"%s"}]}',
+    b'{"tags":{"%s":["ok"]}}',
+    b'{"tags":{"ok":["%s"]}}',
+    b'{"favorites":[{"%s":"ok"}]}',
+    b'{"favorites":[{"ok":"%s"}]}',
+    b'{"sources":{"nested":["%s"]}}',
+])
+@pytest.mark.parametrize("escaped", [b"\\ud800", b"\\udc00"])
+def test_lone_surrogates_reject_every_payload_string(template: bytes, escaped: bytes) -> None:
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import strings must be valid UTF-8.") + "$"):
+        sanitize_conversation_import(template % escaped)
+
+
+@pytest.mark.parametrize("template", [
+    b'{"history":[{"role":"user","content":"%s"}]}',
+    b'{"tags":{"%s":["ok"]}}',
+    b'{"tags":{"ok":["%s"]}}',
+    b'{"favorites":[{"%s":"ok"}]}',
+    b'{"favorites":[{"ok":"%s"}]}',
+    b'{"sources":{"nested":["%s"]}}',
+])
+@pytest.mark.parametrize("escaped", [b"\\ud800", b"\\udc00"])
+def test_uploaded_lone_surrogates_make_zero_writes(template: bytes, escaped: bytes) -> None:
+    class UploadedFile:
+        def getvalue(self) -> bytes:
+            return template % escaped
+
+    state = sentinel_state()
+    state.assignments.clear()
+    warnings: list[str] = []
+    successes: list[str] = []
+    apply_uploaded_conversation(UploadedFile(), state, warnings.append, successes.append)
+    assert state.assignments == []
+    assert warnings == ["Conversation import rejected: Import strings must be valid UTF-8."]
+    assert successes == []
+
+
+def test_json_depth_limit_and_parser_recursion_reject() -> None:
+    nested: object = None
+    for _ in range(MAX_JSON_DEPTH - 1):
+        nested = {"nested": nested}
+    assert sanitize_conversation_import(raw({"sources": nested})) == ({}, ["Ignored legacy export-only key: sources."])
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import nesting exceeds 32 containers.") + "$"):
+        sanitize_conversation_import(raw({"sources": {"nested": nested}}))
+    very_deep = b'{"sources":' + b"[" * 2_000 + b"null" + b"]" * 2_000 + b"}"
+    with pytest.raises(ConversationImportError, match="^" + re.escape("Import nesting exceeds 32 containers.") + "$"):
+        sanitize_conversation_import(very_deep)
+
+
+def test_streamlit_uploader_wiring_ast() -> None:
+    module = ast.parse(Path("streamlit_app.py").read_text(encoding="utf-8"))
+    imports = [node for node in ast.walk(module) if isinstance(node, ast.ImportFrom) and node.module == "conversation_import"]
+    assert len(imports) == 1
+    assert [(alias.name, alias.asname) for alias in imports[0].names] == [("apply_uploaded_conversation", None)]
+    upload_ifs = [node for node in ast.walk(module) if isinstance(node, ast.If) and isinstance(node.test, ast.Name) and node.test.id == "uploaded_file"]
+    assert len(upload_ifs) == 1
+    body = upload_ifs[0].body
+    assert len(body) == 1 and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Call)
+    call = body[0].value
+    assert isinstance(call.func, ast.Name) and call.func.id == "apply_uploaded_conversation"
+    assert call.keywords == []
+    assert len(call.args) == 4
+    assert isinstance(call.args[0], ast.Name) and call.args[0].id == "uploaded_file"
+    assert [ast.unparse(arg) for arg in call.args[1:]] == ["st.session_state", "st.warning", "st.success"]
+
+
+def test_uploaded_handler_reads_bytes_applies_valid_data_and_warns_rejection() -> None:
+    class UploadedFile:
+        def __init__(self, raw_bytes: bytes) -> None:
+            self.raw, self.calls = raw_bytes, 0
+        def getvalue(self) -> bytes:
+            self.calls += 1
+            return self.raw
+
+    valid_state, invalid_state = sentinel_state(), sentinel_state()
+    collection, chroma_client = valid_state["collection"], valid_state["chroma_client"]
+    current_sources, source_filters = valid_state["current_sources"], valid_state["source_filters"]
+    tts_queue, tts_worker = valid_state["tts_queue"], valid_state["tts_worker"]
+    valid_state.assignments.clear()
+    warnings: list[str] = []
+    successes: list[str] = []
+    upload = UploadedFile(raw(valid_payload()))
+    apply_uploaded_conversation(upload, valid_state, warnings.append, successes.append)
+    assert upload.calls == 1
+    assert valid_state["collection"] is collection
+    assert valid_state["chroma_client"] is chroma_client
+    assert valid_state["current_sources"] is current_sources
+    assert valid_state["source_filters"] is source_filters
+    assert valid_state["tts_queue"] is tts_queue
+    assert valid_state["tts_worker"] is tts_worker
+    assert valid_state.assignments == ["conversation_history", "tags", "favorite_responses"]
+    assert warnings == []
+    assert successes == ["Conversation import complete."]
+    invalid_state.assignments.clear()
+    invalid_warnings: list[str] = []
+    invalid_successes: list[str] = []
+    apply_uploaded_conversation(UploadedFile(b"{"), invalid_state, invalid_warnings.append, invalid_successes.append)
+    assert invalid_state.assignments == []
+    assert invalid_warnings[0].startswith("Conversation import rejected:")
+    assert invalid_successes == []


### PR DESCRIPTION
## Issue

Implements #9 on the maintained GUI lineage. This PR does not close the issue automatically; closure follows the evidence comment after merge.

- Canonical plan: https://github.com/sriharshaguthikonda/easy-local-rag/blob/main/docs/issues/ISSUE-009-validate-conversation-import.md
- Immutable canonical plan: https://github.com/sriharshaguthikonda/easy-local-rag/blob/8497efca7aa021bef3757c6b87ba8f4a7824fbc5/docs/issues/ISSUE-009-validate-conversation-import.md
- JIT packet: https://github.com/sriharshaguthikonda/easy-local-rag/blob/main/docs/superpowers/plans/2026-07-24-issue-009-validate-conversation-import-implementation.md
- Immutable JIT packet: https://github.com/sriharshaguthikonda/easy-local-rag/blob/fd11bb7d706665b4094a088aaa0a97546b205135/docs/superpowers/plans/2026-07-24-issue-009-validate-conversation-import-implementation.md
- Frozen target/base: `daecce8a27f50da39284f5519d77b835905209f6`

## Changes

- Replace direct conversation-state assignment with strict, atomic import validation.
- Enforce raw-size, schema, count, UTF-8 byte, depth, numeric, and lone-surrogate limits.
- Reject duplicate JSON object names before decoding can overwrite an invalid member.
- Keep exporter schema, dependencies, and unrelated entry points unchanged.
- Route the Streamlit uploader through the validated import boundary.

## Commit boundaries

- `1bfa7c65e5190869fbc06734b3eb349d9e2310e5` — TDD implementation.
- `9e77fcf628eb9caaf563da133e4186930769eb61` — accepted review fix for duplicate-key validation bypass.

## Verification

- Required RED: focused collection failed because `MAX_FAVORITES` was absent.
- Initial GREEN: 67 focused tests passed.
- Review RED: 3 duplicate-key payloads were incorrectly accepted.
- Final GREEN: 70 focused tests passed; duplicate subset 3/3 passed.
- `python -m py_compile conversation_import.py streamlit_app.py rag_gui.py GUI_direct_search.py`: pass.
- `git diff --check daecce8a27f50da39284f5519d77b835905209f6..9e77fcf628eb9caaf563da133e4186930769eb61`: pass.
- Full `python -m pytest tests -q`: stops only on the frozen-baseline missing `PyQt5` collection errors in `tests/test_gui_settings.py` and `tests/test_rag_gui_comprehensive.py`; no issue-specific failure.
- Changed files: only `conversation_import.py`, `streamlit_app.py`, `tests/test_conversation_import.py`.

## Rollback

Revert `9e77fcf` then `1bfa7c6`; no schema migration, dependency change, or persistent-state conversion is required.
