### PR TITLE
fix(#15): atomically write vault JSON

### DIFF
--- a/Vault_json_creation_from_HTMLs.py
+++ b/Vault_json_creation_from_HTMLs.py
@@ -1,151 +1,96 @@
-import os
-from tkinter import filedialog, Tk
-import re
-from bs4 import BeautifulSoup
-from multiprocessing import Pool, cpu_count
-from tqdm import tqdm
-import json
 import hashlib
-import nltk.data  # Import NLTK sentence tokenizer
+import os
+import re
+from multiprocessing import Pool, cpu_count
+from pathlib import Path
+from typing import Any
+
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+import nltk
 
 from rag_config import get_optional_path
 from vault_store import atomic_write_json, load_vault, merge_vault_entries
 
 
-"""
-TODO: after this u will have to
-ollama serve
-then you can run
-
-"c:/Users/deletable/OneDrive/Windows_software/openai whisper/openai/Scripts/python.exe" c:/Users/deletable/OneDrive/easy-local-rag/force_GPU_localrag_no_rewrite.py
-
-TODO: vault file should have the full file name and the modification date and if the file is modified then we will update th contents associated with the file or else skip the file
-
-"""
-
-# Initialize NLTK sentence tokenizer
-nltk.download("punkt")
-sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
+def _get_sentence_tokenizer() -> Any:
+    try:
+        return nltk.data.load("tokenizers/punkt/english.pickle")
+    except LookupError:
+        nltk.download("punkt", quiet=True)
+        return nltk.data.load("tokenizers/punkt/english.pickle")
 
 
-# Function to clean text from unwanted characters
 def clean_text(text):
-    # Replace special characters with a space or remove them as needed
-    cleaned_text = re.sub(r"[^\x00-\x7F]+", " ", text)  # Remove non-ASCII characters
-    cleaned_text = (
-        re.sub(r"\s+", " ", cleaned_text).strip() + " "
-    )  # Normalize whitespace
-    return cleaned_text
+    cleaned_text = re.sub(r"[^\x00-\x7F]+", " ", text)
+    return re.sub(r"\s+", " ", cleaned_text).strip() + " "
 
 
-# Function to extract text from a single HTML file
 def extract_text_from_html(file_path):
     try:
         with open(file_path, "r", encoding="utf-8") as html_file:
-            soup = BeautifulSoup(html_file, "html.parser")
-            text = soup.get_text(separator=" ", strip=True)
-            cleaned_text = clean_text(text)
-            return cleaned_text
-    except Exception as e:
-        print(f"Error processing file {file_path}: {e}")
+            return clean_text(BeautifulSoup(html_file, "html.parser").get_text(separator=" ", strip=True))
+    except Exception as error:
+        print(f"Error processing file {file_path}: {error}")
         return ""
 
 
-# Function to generate a unique identifier for a chunk
 def generate_chunk_id(text):
-    hash_object = hashlib.sha256(text.encode())
-    return hash_object.hexdigest()
+    return hashlib.sha256(text.encode()).hexdigest()
 
 
-# Function to split text into chunks based on sentence boundaries
 def split_into_chunks(text):
-    # Use NLTK sentence tokenizer for more accurate sentence splitting
-    sentences = sentence_tokenizer.tokenize(text.strip())
     chunks = []
     current_chunk = ""
-    for sentence in sentences:
-        if len(current_chunk) + len(sentence) + 1 < 1000:  # +1 for space
+    for sentence in _get_sentence_tokenizer().tokenize(text.strip()):
+        if len(current_chunk) + len(sentence) + 1 < 1000:
             current_chunk += (sentence + " ").strip()
         else:
             if current_chunk:
-                chunks.append(
-                    {
-                        "id": generate_chunk_id(current_chunk),
-                        "text": current_chunk.strip(),
-                    }
-                )
+                chunks.append({"id": generate_chunk_id(current_chunk), "text": current_chunk.strip()})
             current_chunk = (sentence + " ").strip()
-    # Add the last chunk
     if current_chunk:
-        chunks.append(
-            {
-                "id": generate_chunk_id(current_chunk),
-                "text": current_chunk.strip(),
-            }
-        )
-
+        chunks.append({"id": generate_chunk_id(current_chunk), "text": current_chunk.strip()})
     return chunks
 
 
-# Function to convert HTML files to text and save to JSON
-def convert_html_to_json(directory_path):
-    vault_path = "vault.json"
+def convert_html_to_json(directory_path: str | os.PathLike[str], vault_path: str | os.PathLike[str] = "vault.json") -> None:
+    source = Path(directory_path).expanduser().resolve()
+    if not source.exists():
+        raise FileNotFoundError(source)
+    if not source.is_dir():
+        raise NotADirectoryError(source)
     existing_data = load_vault(vault_path)
-
-    html_files = []
-    for root, _, files in os.walk(directory_path):
-        for file in files:
-            if file.lower().endswith((".htm", ".html", ".xhtml", ".shtml", ".dhtml")):
-                html_files.append(os.path.join(root, file))
-
-    # Use multiprocessing to process files in parallel
+    html_files = [
+        Path(root) / file_name
+        for root, _, files in os.walk(source)
+        for file_name in files
+        if file_name.lower().endswith((".htm", ".html", ".xhtml", ".shtml", ".dhtml"))
+    ]
     with Pool(cpu_count()) as pool:
-        all_texts = list(
-            tqdm(
-                pool.imap(extract_text_from_html, html_files),
-                total=len(html_files),
-                desc="Processing HTML files",
-            )
-        )
-
+        all_texts = list(tqdm(pool.imap(extract_text_from_html, map(str, html_files)), total=len(html_files), desc="Processing HTML files"))
     new_data = []
     for file_path, text in zip(html_files, all_texts):
         if text:
-            modification_time = os.path.getmtime(file_path)
-            if not any(
-                entry["file_name"] == os.path.normpath(file_path)
-                and entry["modification_time"] == modification_time
-                for entry in existing_data
-            ):
-                # Split text into chunks with more sophisticated sentence splitting
-                chunks = split_into_chunks(text)
-
-                new_data.append(
-                    {
-                        "file_name": os.path.normpath(file_path),
-                        "modification_time": modification_time,
-                        "chunks": chunks,
-                    }
-                )
-            else:
-                print(f"Skipping file {file_path} as it is already in the vault.json")
-
-    merged_data = merge_vault_entries(existing_data, new_data)
-    atomic_write_json(vault_path, merged_data)
-
+            new_data.append({
+                "file_name": os.path.normpath(str(file_path.resolve())),
+                "modification_time": file_path.stat().st_mtime,
+                "chunks": split_into_chunks(text),
+                "content_hash": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            })
+    atomic_write_json(vault_path, merge_vault_entries(existing_data, new_data))
     print(f"Vault updated: {len(new_data)} new/updated entries written to {vault_path}.")
 
 
-# Main function to handle folder selection and processing
 def main():
     configured_path = get_optional_path("EASY_RAG_VAULT_SOURCE_DIR")
     if configured_path and configured_path.exists():
         directory_path = str(configured_path)
     else:
+        from tkinter import Tk, filedialog
         root = Tk()
-        root.withdraw()  # Hide the main window
-        directory_path = filedialog.askdirectory()  # Open the folder selection dialog
-
+        root.withdraw()
+        directory_path = filedialog.askdirectory()
     if directory_path:
         convert_html_to_json(directory_path)
 

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -6,6 +6,7 @@ import os
 import stat
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -140,15 +141,26 @@ def test_schema_backward_compatibility_and_invalid_in_memory_data(tmp_path):
     assert not (tmp_path / "missing").exists()
 
 
-def test_corrupt_input_backup_then_valid_rebuild_is_unique_and_byte_exact(tmp_path):
+def test_corrupt_input_backup_then_valid_rebuild_is_unique_and_byte_exact(tmp_path, monkeypatch):
     vault = tmp_path / "vault.json"
-    collision = tmp_path / "vault.json.invalid.20000101T000000000000Z.1.bak"
+    timestamp = "20000101T000000000000Z"
+    class FixedDatetime:
+        @staticmethod
+        def now(tz): return datetime(2000, 1, 1, tzinfo=timezone.utc)
+    collision = tmp_path / f"vault.json.invalid.{timestamp}.77.1.bak"
     collision.write_bytes(b"collision")
-    for bad in (b"\xff", b"{bad", b'{"not":"a-list"}'):
+    monkeypatch.setattr(vault_store, "datetime", FixedDatetime)
+    monkeypatch.setattr(vault_store.os, "getpid", lambda: 77)
+    expected_names = [
+        f"vault.json.invalid.{timestamp}.77.bak",
+        f"vault.json.invalid.{timestamp}.77.2.bak",
+        f"vault.json.invalid.{timestamp}.77.3.bak",
+    ]
+    for bad, expected_name in zip((b"\xff", b"{bad", b'{"not":"a-list"}'), expected_names):
         vault.write_bytes(bad)
         assert load_vault(vault) == []
-        backups = [p for p in tmp_path.glob("vault.json.invalid.*.bak") if p != collision]
-        assert any(p.read_bytes() == bad for p in backups)
+        backup = tmp_path / expected_name
+        assert backup.exists() and backup.read_bytes() == bad
     data = _valid_payload()
     atomic_write_json(vault, data)
     assert load_vault(vault) == data

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -35,11 +35,6 @@ def _valid_payload():
     return [_entry()]
 
 
-def _assert_preserved(vault, old, exc_info):
-    assert exc_info.value is exc_info.value
-    assert vault.read_bytes() == old
-
-
 def test_load_missing_and_zero_byte_return_empty(tmp_path):
     missing = tmp_path / "missing.json"
     empty = tmp_path / "empty.json"

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -240,18 +240,32 @@ def test_cleanup_failure_preserves_primary_and_records_residual_temp(tmp_path, m
 def test_atomic_temp_order_deterministic_bytes_parent_and_mode(tmp_path, monkeypatch):
     events = []
     vault = tmp_path / "nested" / "vault.json"
+    temp_parents = []
     original_dump, original_fsync, original_replace, original_chmod = vault_store.json.dump, vault_store.os.fsync, vault_store.os.replace, vault_store.os.chmod
+    original_temp = vault_store.tempfile.NamedTemporaryFile
     def recording_dump(*args, **kwargs): events.append("dump"); return original_dump(*args, **kwargs)
     def recording_fsync(*args): events.append("fsync"); return original_fsync(*args)
     def recording_replace(src, dst): events.append("replace"); return original_replace(src, dst)
     def recording_chmod(path, mode): events.append("chmod"); return original_chmod(path, mode)
+    class RecordingHandle:
+        def __init__(self, handle): self._handle = handle; temp_parents.append(Path(handle.name).parent)
+        @property
+        def name(self): return self._handle.name
+        def write(self, value): return self._handle.write(value)
+        def flush(self): events.append("flush"); return self._handle.flush()
+        def fileno(self): return self._handle.fileno()
+        def close(self): events.append("close"); return self._handle.close()
     monkeypatch.setattr(vault_store.json, "dump", recording_dump); monkeypatch.setattr(vault_store.os, "fsync", recording_fsync); monkeypatch.setattr(vault_store.os, "replace", recording_replace); monkeypatch.setattr(vault_store.os, "chmod", recording_chmod)
+    monkeypatch.setattr(vault_store.tempfile, "NamedTemporaryFile", lambda *args, **kwargs: RecordingHandle(original_temp(*args, **kwargs)))
     atomic_write_json(vault, [_entry("é.html")])
-    assert vault.parent.exists() and events == ["dump", "fsync", "replace"]
-    assert vault.read_bytes().endswith(b"\n") and "é.html".encode() in vault.read_bytes()
+    expected = (json.dumps([_entry("é.html")], ensure_ascii=False, allow_nan=False, sort_keys=True, indent=2) + "\n").encode("utf-8")
+    assert vault.parent.exists() and temp_parents == [vault.parent]
+    assert events == ["dump", "flush", "fsync", "close", "replace"]
+    assert vault.read_bytes() == expected and b"\r\n" not in expected
     original_mode = stat.S_IMODE(vault.stat().st_mode)
     events.clear(); atomic_write_json(vault, [_entry("é.html")])
-    assert events == ["dump", "fsync", "chmod", "replace"]
+    assert temp_parents == [vault.parent, vault.parent]
+    assert events == ["dump", "flush", "fsync", "close", "chmod", "replace"]
     assert stat.S_IMODE(vault.stat().st_mode) == original_mode
 
 

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -65,13 +65,20 @@ def test_unchanged_rerun_keeps_one_entry_and_object_value(tmp_path):
 
 def test_changed_mtime_with_unchanged_or_absent_hash_replaces_once(tmp_path):
     alias = str(tmp_path / "native" / "." / "sub" / ".." / "doc.html")
+    native = str(tmp_path / "native" / "doc.html")
     for old_hash, new_hash in ((HASH_A, HASH_A), (None, None)):
-        existing = [_entry(alias, 1, old_hash, chunks=[{"id": HASH_A, "text": "old"}])]
-        incoming = [_entry(alias, 2, new_hash, chunks=[{"id": HASH_B, "text": "new"}])]
+        existing = [
+            _entry("before.html"),
+            _entry(alias, 1, old_hash, chunks=[{"id": HASH_A, "text": "old"}]),
+            _entry("after.html"),
+        ]
+        incoming = [_entry(native, 2, new_hash, chunks=[{"id": HASH_B, "text": "new"}])]
+        old_existing, old_incoming = copy.deepcopy(existing), copy.deepcopy(incoming)
         merged = merge_vault_entries(existing, incoming)
-        assert len(merged) == 1
-        assert merged[0]["modification_time"] == 2
-        assert merged[0]["chunks"] == incoming[0]["chunks"]
+        assert len(merged) == 3 and merged[0] is existing[0] and merged[2] is existing[2]
+        assert merged[1]["file_name"] == native and merged[1]["modification_time"] == 2
+        assert merged[1]["chunks"] == incoming[0]["chunks"]
+        assert existing == old_existing and incoming == old_incoming
 
 
 def test_same_mtime_changed_hash_replaces_once():

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -104,6 +104,16 @@ def test_legacy_hash_upgrade_merge_winners_and_no_mutation():
     assert kept[0] is hashed[0]
     assert kept[0] == old_hashed[0]
     assert hashed == old_hashed and missing == old_missing
+    alias = str(Path("alias-parent") / "." / "nested" / ".." / "a.html")
+    native = str(Path("alias-parent") / "a.html")
+    neighbors = [_entry("before.html"), _entry(alias, 1, None, chunks=[{"id": HASH_A, "text": "old"}], retained="yes"), _entry("after.html")]
+    replacement = [_entry(native, 1, HASH_B, chunks=[{"id": HASH_B, "text": "new"}], incoming_only="yes")]
+    old_neighbors, old_replacement = copy.deepcopy(neighbors), copy.deepcopy(replacement)
+    merged_neighbors = merge_vault_entries(neighbors, replacement)
+    assert merged_neighbors[0] is neighbors[0] and merged_neighbors[2] is neighbors[2]
+    assert merged_neighbors[1]["file_name"] == native and merged_neighbors[1]["chunks"] == replacement[0]["chunks"]
+    assert merged_neighbors[1]["retained"] == "yes" and merged_neighbors[1]["incoming_only"] == "yes"
+    assert neighbors == old_neighbors and replacement == old_replacement
 
 
 def test_schema_backward_compatibility_and_invalid_in_memory_data(tmp_path):

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -344,14 +344,35 @@ def test_builder_rerun_and_same_mtime_content_change(tmp_path, monkeypatch):
 
 
 def test_builder_import_is_side_effect_free(tmp_path):
-    fake_root = tmp_path / "fake"
-    fake = fake_root / "nltk"; fake.mkdir(parents=True)
-    (fake / "__init__.py").write_text("from . import data\ndef download(*a, **k): raise AssertionError('download')\n", encoding="utf-8")
-    (fake / "data.py").write_text("def load(*a, **k): raise AssertionError('load')\n", encoding="utf-8")
-    env = os.environ | {"PYTHONPATH": str(fake_root) + os.pathsep + str(Path.cwd()), "PYTHONDONTWRITEBYTECODE": "1"}
-    result = subprocess.run([sys.executable, "-c", "import Vault_json_creation_from_HTMLs"], cwd=tmp_path, env=env, capture_output=True, text=True)
+    sentinels = """
+import multiprocessing
+import os
+import sys
+import types
+def fail(name):
+    def raised(*args, **kwargs):
+        raise AssertionError(name)
+    return raised
+nltk = types.ModuleType('nltk')
+nltk.download = fail('nltk.download')
+nltk.data = types.SimpleNamespace(load=fail('nltk.data.load'))
+sys.modules['nltk'] = nltk
+multiprocessing.Pool = fail('multiprocessing.Pool')
+os.walk = fail('os.walk')
+import vault_store
+vault_store.atomic_write_json = fail('atomic_write_json')
+tkinter = types.ModuleType('tkinter')
+tkinter.Tk = fail('tkinter.Tk')
+filedialog = types.ModuleType('tkinter.filedialog')
+filedialog.askdirectory = fail('filedialog.askdirectory')
+sys.modules['tkinter'] = tkinter
+sys.modules['tkinter.filedialog'] = filedialog
+import Vault_json_creation_from_HTMLs
+"""
+    env = os.environ | {"PYTHONPATH": str(Path.cwd()), "PYTHONDONTWRITEBYTECODE": "1"}
+    result = subprocess.run([sys.executable, "-c", sentinels], cwd=tmp_path, env=env, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
-    assert not (tmp_path / "vault.json").exists()
+    assert not list(tmp_path.iterdir())
 
 
 def test_owned_writer_has_no_append_mode():

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -332,15 +332,22 @@ def test_builder_rerun_and_same_mtime_content_change(tmp_path, monkeypatch):
     sys.modules.pop("Vault_json_creation_from_HTMLs", None)
     import Vault_json_creation_from_HTMLs as builder
     source = tmp_path / "source"; source.mkdir(); html = source / "a.html"; html.write_text("<p>first text.</p>", encoding="utf-8")
+    neighbor = source / "b.html"; neighbor.write_text("<p>neighbor text.</p>", encoding="utf-8")
     vault = tmp_path / "vault.json"
     monkeypatch.setattr(builder, "_get_sentence_tokenizer", lambda: type("T", (), {"tokenize": lambda _, text: [text]})())
     monkeypatch.setattr(builder, "Pool", lambda *_: type("P", (), {"__enter__": lambda s: s, "__exit__": lambda *a: None, "imap": lambda s, fn, values: map(fn, values)})())
     monkeypatch.setattr(builder, "tqdm", lambda values, **_: values)
     builder.convert_html_to_json(source, vault); first = load_vault(vault)
+    original_index = next(index for index, entry in enumerate(first) if entry["file_name"] == str(html.resolve()))
+    first_a = first[original_index]
     builder.convert_html_to_json(source, vault); assert load_vault(vault) == first
     mtime = html.stat().st_mtime; html.write_text("<p>second text.</p>", encoding="utf-8"); os.utime(html, (mtime, mtime))
     builder.convert_html_to_json(source, vault); changed = load_vault(vault)
-    assert len(changed) == 1 and changed[0]["content_hash"] != first[0]["content_hash"]
+    changed_a_index = next(index for index, entry in enumerate(changed) if entry["file_name"] == str(html.resolve()))
+    changed_a = changed[changed_a_index]
+    assert len(changed) == 2 and changed_a_index == original_index
+    assert changed_a["content_hash"] != first_a["content_hash"]
+    assert changed_a["chunks"] == builder.split_into_chunks("second text. ")
 
 
 def test_builder_import_is_side_effect_free(tmp_path):

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -56,8 +56,10 @@ def test_unchanged_rerun_keeps_one_entry_and_object_value(tmp_path):
     vault = tmp_path / "vault.json"
     atomic_write_json(vault, merged)
     first = vault.read_bytes()
+    assert load_vault(vault) == [existing[0]]
     merged_again = merge_vault_entries(merged, incoming)
     atomic_write_json(vault, merged_again)
+    assert load_vault(vault) == [existing[0]]
     assert len(merged_again) == 1
     assert merged_again[0] is merged[0]
     assert vault.read_bytes() == first

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -162,39 +162,72 @@ def test_dump_encode_write_flush_and_close_failures_preserve_target(tmp_path, mo
         old = b"old target"
         vault.write_bytes(old)
         sentinel = RuntimeError(event)
+        events = []
+        payload = _valid_payload()
+        payload_before = copy.deepcopy(payload)
         original_dump = vault_store.json.dump
         original_temp = vault_store.tempfile.NamedTemporaryFile
+        original_fsync = vault_store.os.fsync
+        original_chmod = vault_store.os.chmod
+        original_replace = vault_store.os.replace
 
         if event == "dump":
             def fail_dump(data, handle, **kwargs):
+                events.extend(("dump", "dump-fail"))
                 handle.write("[")
                 raise sentinel
             monkeypatch.setattr(vault_store.json, "dump", fail_dump)
         else:
+            def recording_dump(*args, **kwargs):
+                events.append("dump")
+                return original_dump(*args, **kwargs)
+            monkeypatch.setattr(vault_store.json, "dump", recording_dump)
             class Wrapped:
                 def __init__(self, handle): self._handle = handle
                 @property
                 def name(self): return self._handle.name
                 def write(self, value):
-                    if event == "write": raise sentinel
+                    if event == "write":
+                        events.append("encode-write-fail")
+                        raise sentinel
                     return self._handle.write(value)
                 def flush(self):
-                    if event == "flush": raise sentinel
+                    if event == "flush":
+                        events.append("flush-fail")
+                        raise sentinel
+                    events.append("flush")
                     return self._handle.flush()
                 def fileno(self): return self._handle.fileno()
                 def close(self):
                     result = self._handle.close()
-                    if event == "close": raise sentinel
+                    if event == "close":
+                        events.append("close-fail")
+                        raise sentinel
                     return result
             def wrapped_temp(*args, **kwargs): return Wrapped(original_temp(*args, **kwargs))
             monkeypatch.setattr(vault_store.tempfile, "NamedTemporaryFile", wrapped_temp)
+        monkeypatch.setattr(vault_store.os, "fsync", lambda descriptor: (events.append("fsync"), original_fsync(descriptor))[1])
+        monkeypatch.setattr(vault_store.os, "chmod", lambda *_: events.append("chmod"))
+        monkeypatch.setattr(vault_store.os, "replace", lambda *_: events.append("replace"))
         with pytest.raises(RuntimeError) as raised:
-            atomic_write_json(vault, _valid_payload())
+            atomic_write_json(vault, payload)
         assert raised.value is sentinel
         assert vault.read_bytes() == old
+        assert payload == payload_before
+        expected_prefix = {
+            "dump": ["dump", "dump-fail"],
+            "write": ["dump", "encode-write-fail"],
+            "flush": ["dump", "flush-fail"],
+            "close": ["dump", "flush", "fsync", "close-fail"],
+        }[event]
+        assert events[:len(expected_prefix)] == expected_prefix
+        assert "chmod" not in events and "replace" not in events
         assert not list(tmp_path.glob(f".{vault.name}.*.tmp"))
         monkeypatch.setattr(vault_store.json, "dump", original_dump)
         monkeypatch.setattr(vault_store.tempfile, "NamedTemporaryFile", original_temp)
+        monkeypatch.setattr(vault_store.os, "fsync", original_fsync)
+        monkeypatch.setattr(vault_store.os, "chmod", original_chmod)
+        monkeypatch.setattr(vault_store.os, "replace", original_replace)
 
 
 def test_fsync_failure_preserves_target_cleans_temp_and_reraises(tmp_path, monkeypatch):

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -82,12 +82,20 @@ def test_changed_mtime_with_unchanged_or_absent_hash_replaces_once(tmp_path):
 
 
 def test_same_mtime_changed_hash_replaces_once():
-    existing = [_entry("a.html", 1, HASH_A, chunks=[{"id": HASH_A, "text": "old"}])]
-    incoming = [_entry("a.html", 1, HASH_B, chunks=[{"id": HASH_B, "text": "new"}])]
+    alias = str(Path("same-mtime") / "." / "nested" / ".." / "a.html")
+    native = str(Path("same-mtime") / "a.html")
+    existing = [
+        _entry("before.html"),
+        _entry(alias, 1, HASH_A, chunks=[{"id": HASH_A, "text": "old"}]),
+        _entry("after.html"),
+    ]
+    incoming = [_entry(native, 1, HASH_B, chunks=[{"id": HASH_B, "text": "new"}])]
+    old_existing, old_incoming = copy.deepcopy(existing), copy.deepcopy(incoming)
     merged = merge_vault_entries(existing, incoming)
-    assert len(merged) == 1
-    assert merged[0]["content_hash"] == HASH_B
-    assert merged[0]["chunks"] == incoming[0]["chunks"]
+    assert len(merged) == 3 and merged[0] is existing[0] and merged[2] is existing[2]
+    assert merged[1]["file_name"] == native and merged[1]["content_hash"] == HASH_B
+    assert merged[1]["chunks"] == incoming[0]["chunks"]
+    assert existing == old_existing and incoming == old_incoming
 
 
 def test_legacy_hash_upgrade_merge_winners_and_no_mutation():

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -1,48 +1,298 @@
+import ast
+import copy
+import hashlib
 import json
+import os
+import stat
+import subprocess
+import sys
 from pathlib import Path
 
+import pytest
+
+import vault_store
 from vault_store import atomic_write_json, load_vault, merge_vault_entries
 
 
-def test_load_vault_missing_returns_empty(tmp_path):
-    assert load_vault(tmp_path / "vault.json") == []
+HASH_A = "a" * 64
+HASH_B = "b" * 64
 
 
-def test_merge_vault_entries_replaces_changed_mod_time():
-    existing = [
-        {"file_name": "a.html", "modification_time": 10, "chunks": ["old"]},
-        {"file_name": "b.html", "modification_time": 20, "chunks": ["b"]},
-    ]
-    incoming = [
-        {"file_name": "a.html", "modification_time": 11, "chunks": ["new"]},
-        {"file_name": "c.html", "modification_time": 30, "chunks": ["c"]},
-    ]
+def _entry(path="a.html", mtime=1, content_hash=HASH_A, chunks=None, **extra):
+    value = {
+        "file_name": path,
+        "modification_time": mtime,
+        "chunks": chunks if chunks is not None else [{"id": HASH_A, "text": "text"}],
+    }
+    if content_hash is not None:
+        value["content_hash"] = content_hash
+    value.update(extra)
+    return value
+
+
+def _valid_payload():
+    return [_entry()]
+
+
+def _assert_preserved(vault, old, exc_info):
+    assert exc_info.value is exc_info.value
+    assert vault.read_bytes() == old
+
+
+def test_load_missing_and_zero_byte_return_empty(tmp_path):
+    missing = tmp_path / "missing.json"
+    empty = tmp_path / "empty.json"
+    empty.write_bytes(b"")
+    assert load_vault(missing) == []
+    assert load_vault(empty) == []
+    assert not list(tmp_path.glob("*.invalid.*.bak"))
+
+
+def test_unchanged_rerun_keeps_one_entry_and_object_value(tmp_path):
+    path = str(tmp_path / "folder" / "." / "child" / ".." / "a.html")
+    existing = [_entry(path, 1, HASH_A, marker="existing")]
+    incoming = [_entry(path, 1, HASH_A, marker="incoming")]
+    before_existing, before_incoming = copy.deepcopy(existing), copy.deepcopy(incoming)
     merged = merge_vault_entries(existing, incoming)
-    by_name = {entry["file_name"]: entry for entry in merged}
-
-    assert len(merged) == 3
-    assert by_name["a.html"]["modification_time"] == 11
-    assert by_name["a.html"]["chunks"] == ["new"]
-    assert by_name["b.html"]["modification_time"] == 20
-    assert by_name["c.html"]["modification_time"] == 30
-
-
-def test_atomic_write_json_writes_valid_json(tmp_path):
+    assert merged == [existing[0]]
+    assert merged[0] is existing[0]
+    assert existing == before_existing and incoming == before_incoming
     vault = tmp_path / "vault.json"
-    payload = [{"file_name": "a.html", "modification_time": 10}]
-    atomic_write_json(vault, payload)
+    atomic_write_json(vault, merged)
+    first = vault.read_bytes()
+    merged_again = merge_vault_entries(merged, incoming)
+    atomic_write_json(vault, merged_again)
+    assert len(merged_again) == 1
+    assert merged_again[0] is merged[0]
+    assert vault.read_bytes() == first
 
-    with vault.open("r", encoding="utf-8") as handle:
-        assert json.load(handle) == payload
+
+def test_changed_mtime_with_unchanged_or_absent_hash_replaces_once(tmp_path):
+    alias = str(tmp_path / "native" / "." / "sub" / ".." / "doc.html")
+    for old_hash, new_hash in ((HASH_A, HASH_A), (None, None)):
+        existing = [_entry(alias, 1, old_hash, chunks=[{"id": HASH_A, "text": "old"}])]
+        incoming = [_entry(alias, 2, new_hash, chunks=[{"id": HASH_B, "text": "new"}])]
+        merged = merge_vault_entries(existing, incoming)
+        assert len(merged) == 1
+        assert merged[0]["modification_time"] == 2
+        assert merged[0]["chunks"] == incoming[0]["chunks"]
 
 
-def test_load_vault_backs_up_invalid_json(tmp_path):
+def test_same_mtime_changed_hash_replaces_once():
+    existing = [_entry("a.html", 1, HASH_A, chunks=[{"id": HASH_A, "text": "old"}])]
+    incoming = [_entry("a.html", 1, HASH_B, chunks=[{"id": HASH_B, "text": "new"}])]
+    merged = merge_vault_entries(existing, incoming)
+    assert len(merged) == 1
+    assert merged[0]["content_hash"] == HASH_B
+    assert merged[0]["chunks"] == incoming[0]["chunks"]
+
+
+def test_legacy_hash_upgrade_merge_winners_and_no_mutation():
+    existing = [_entry("a.html", 1, None, chunks=[{"id": HASH_A, "text": "old"}], keep="yes", collision="old")]
+    incoming = [_entry("a.html", 1, HASH_A, chunks=[{"id": HASH_B, "text": "new"}], collision="new", added="yes")]
+    old_existing, old_incoming = copy.deepcopy(existing), copy.deepcopy(incoming)
+    merged = merge_vault_entries(existing, incoming)
+    assert merged[0] is not existing[0]
+    assert merged[0]["chunks"] == incoming[0]["chunks"]
+    assert merged[0]["keep"] == "yes" and merged[0]["collision"] == "new"
+    assert existing == old_existing and incoming == old_incoming
+    hashed = [_entry("a.html", 1, HASH_A, chunks=[{"id": HASH_A, "text": "keep"}], keep="yes")]
+    missing = [_entry("a.html", 1, None, chunks=[{"id": HASH_B, "text": "lose"}], keep="no")]
+    old_hashed, old_missing = copy.deepcopy(hashed), copy.deepcopy(missing)
+    kept = merge_vault_entries(hashed, missing)
+    assert kept[0] is hashed[0]
+    assert kept[0] == old_hashed[0]
+    assert hashed == old_hashed and missing == old_missing
+
+
+def test_schema_backward_compatibility_and_invalid_in_memory_data(tmp_path):
+    legacy = [_entry(content_hash=None, extra="ok")]
+    atomic_write_json(tmp_path / "legacy.json", legacy)
+    assert load_vault(tmp_path / "legacy.json") == legacy
+    invalids = [
+        {},
+        ["entry"],
+        [{"file_name": "", "modification_time": 1, "chunks": []}],
+        [{"file_name": "a", "modification_time": True, "chunks": []}],
+        [{"file_name": "a", "modification_time": float("nan"), "chunks": []}],
+        [{"file_name": "a", "modification_time": 1, "chunks": ["chunk"]}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [{"id": "x", "text": "x"}]}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [], "content_hash": "x"}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [], 1: "bad"}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [], "unknown": object()}],
+    ]
+    for invalid in invalids:
+        with pytest.raises(ValueError):
+            merge_vault_entries(invalid, [])
+        with pytest.raises(ValueError):
+            atomic_write_json(tmp_path / "missing" / "vault.json", invalid)
+    assert not (tmp_path / "missing").exists()
+
+
+def test_corrupt_input_backup_then_valid_rebuild_is_unique_and_byte_exact(tmp_path):
     vault = tmp_path / "vault.json"
-    vault.write_text("not-json", encoding="utf-8")
+    collision = tmp_path / "vault.json.invalid.20000101T000000000000Z.1.bak"
+    collision.write_bytes(b"collision")
+    for bad in (b"\xff", b"{bad", b'{"not":"a-list"}'):
+        vault.write_bytes(bad)
+        assert load_vault(vault) == []
+        backups = [p for p in tmp_path.glob("vault.json.invalid.*.bak") if p != collision]
+        assert any(p.read_bytes() == bad for p in backups)
+    data = _valid_payload()
+    atomic_write_json(vault, data)
+    assert load_vault(vault) == data
 
-    loaded = load_vault(vault)
-    backups = list(tmp_path.glob("vault.json.invalid.*.bak"))
 
-    assert loaded == []
-    assert not vault.exists()
-    assert len(backups) == 1
+def test_backup_move_failure_leaves_corrupt_target_unchanged(tmp_path, monkeypatch):
+    vault = tmp_path / "vault.json"
+    old = b"{broken"
+    vault.write_bytes(old)
+    sentinel = RuntimeError("rename")
+    monkeypatch.setattr(vault_store.os, "rename", lambda *_: (_ for _ in ()).throw(sentinel))
+    with pytest.raises(RuntimeError) as raised:
+        load_vault(vault)
+    assert raised.value is sentinel
+    assert vault.read_bytes() == old
+    assert not list(tmp_path.glob("*.bak"))
+
+
+def test_dump_encode_write_flush_and_close_failures_preserve_target(tmp_path, monkeypatch):
+    for event in ("dump", "write", "flush", "close"):
+        vault = tmp_path / f"{event}.json"
+        old = b"old target"
+        vault.write_bytes(old)
+        sentinel = RuntimeError(event)
+        original_dump = vault_store.json.dump
+        original_temp = vault_store.tempfile.NamedTemporaryFile
+
+        if event == "dump":
+            def fail_dump(data, handle, **kwargs):
+                handle.write("[")
+                raise sentinel
+            monkeypatch.setattr(vault_store.json, "dump", fail_dump)
+        else:
+            class Wrapped:
+                def __init__(self, handle): self._handle = handle
+                @property
+                def name(self): return self._handle.name
+                def write(self, value):
+                    if event == "write": raise sentinel
+                    return self._handle.write(value)
+                def flush(self):
+                    if event == "flush": raise sentinel
+                    return self._handle.flush()
+                def fileno(self): return self._handle.fileno()
+                def close(self):
+                    result = self._handle.close()
+                    if event == "close": raise sentinel
+                    return result
+            def wrapped_temp(*args, **kwargs): return Wrapped(original_temp(*args, **kwargs))
+            monkeypatch.setattr(vault_store.tempfile, "NamedTemporaryFile", wrapped_temp)
+        with pytest.raises(RuntimeError) as raised:
+            atomic_write_json(vault, _valid_payload())
+        assert raised.value is sentinel
+        assert vault.read_bytes() == old
+        assert not list(tmp_path.glob(f".{vault.name}.*.tmp"))
+        monkeypatch.setattr(vault_store.json, "dump", original_dump)
+        monkeypatch.setattr(vault_store.tempfile, "NamedTemporaryFile", original_temp)
+
+
+def test_fsync_failure_preserves_target_cleans_temp_and_reraises(tmp_path, monkeypatch):
+    vault = tmp_path / "vault.json"; old = b"old"; vault.write_bytes(old); sentinel = RuntimeError("fsync")
+    monkeypatch.setattr(vault_store.os, "fsync", lambda *_: (_ for _ in ()).throw(sentinel))
+    with pytest.raises(RuntimeError) as raised: atomic_write_json(vault, _valid_payload())
+    assert raised.value is sentinel and vault.read_bytes() == old
+    assert not list(tmp_path.glob(".vault.json.*.tmp"))
+
+
+def test_chmod_failure_preserves_target_cleans_temp_and_reraises(tmp_path, monkeypatch):
+    vault = tmp_path / "vault.json"; old = b"old"; vault.write_bytes(old); sentinel = RuntimeError("chmod")
+    monkeypatch.setattr(vault_store.os, "chmod", lambda *_: (_ for _ in ()).throw(sentinel))
+    with pytest.raises(RuntimeError) as raised: atomic_write_json(vault, _valid_payload())
+    assert raised.value is sentinel and vault.read_bytes() == old
+    assert not list(tmp_path.glob(".vault.json.*.tmp"))
+
+
+def test_replace_failure_preserves_target_cleans_temp_and_reraises(tmp_path, monkeypatch):
+    vault = tmp_path / "vault.json"; old = b"old"; vault.write_bytes(old); sentinel = RuntimeError("replace")
+    monkeypatch.setattr(vault_store.os, "replace", lambda *_: (_ for _ in ()).throw(sentinel))
+    with pytest.raises(RuntimeError) as raised: atomic_write_json(vault, _valid_payload())
+    assert raised.value is sentinel and vault.read_bytes() == old
+    assert not list(tmp_path.glob(".vault.json.*.tmp"))
+
+
+def test_cleanup_failure_preserves_primary_and_records_residual_temp(tmp_path, monkeypatch):
+    vault = tmp_path / "vault.json"; old = b"old"; vault.write_bytes(old); sentinel = RuntimeError("replace")
+    monkeypatch.setattr(vault_store.os, "replace", lambda *_: (_ for _ in ()).throw(sentinel))
+    original_unlink = Path.unlink
+    calls = []
+    def fail_unlink(path, *args, **kwargs):
+        if path.name.startswith(".vault.json."):
+            calls.append(path); raise RuntimeError("unlink")
+        return original_unlink(path, *args, **kwargs)
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+    with pytest.raises(RuntimeError) as raised: atomic_write_json(vault, _valid_payload())
+    assert raised.value is sentinel and vault.read_bytes() == old and len(calls) == 1
+    assert any(str(calls[0]) in note and "unlink" in note for note in raised.value.__notes__)
+    assert calls[0].exists()
+
+
+def test_atomic_temp_order_deterministic_bytes_parent_and_mode(tmp_path, monkeypatch):
+    events = []
+    vault = tmp_path / "nested" / "vault.json"
+    original_dump, original_fsync, original_replace, original_chmod = vault_store.json.dump, vault_store.os.fsync, vault_store.os.replace, vault_store.os.chmod
+    def recording_dump(*args, **kwargs): events.append("dump"); return original_dump(*args, **kwargs)
+    def recording_fsync(*args): events.append("fsync"); return original_fsync(*args)
+    def recording_replace(src, dst): events.append("replace"); return original_replace(src, dst)
+    def recording_chmod(path, mode): events.append("chmod"); return original_chmod(path, mode)
+    monkeypatch.setattr(vault_store.json, "dump", recording_dump); monkeypatch.setattr(vault_store.os, "fsync", recording_fsync); monkeypatch.setattr(vault_store.os, "replace", recording_replace); monkeypatch.setattr(vault_store.os, "chmod", recording_chmod)
+    atomic_write_json(vault, [_entry("é.html")])
+    assert vault.parent.exists() and events == ["dump", "fsync", "replace"]
+    assert vault.read_bytes().endswith(b"\n") and "é.html".encode() in vault.read_bytes()
+    original_mode = stat.S_IMODE(vault.stat().st_mode)
+    events.clear(); atomic_write_json(vault, [_entry("é.html")])
+    assert events == ["dump", "fsync", "chmod", "replace"]
+    assert stat.S_IMODE(vault.stat().st_mode) == original_mode
+
+
+def test_builder_rerun_and_same_mtime_content_change(tmp_path, monkeypatch):
+    import nltk
+    monkeypatch.setattr(nltk, "download", lambda *args, **kwargs: None)
+    monkeypatch.setattr(nltk.data, "load", lambda *args, **kwargs: type("T", (), {"tokenize": lambda _, text: [text]})())
+    sys.modules.pop("Vault_json_creation_from_HTMLs", None)
+    import Vault_json_creation_from_HTMLs as builder
+    source = tmp_path / "source"; source.mkdir(); html = source / "a.html"; html.write_text("<p>first text.</p>", encoding="utf-8")
+    vault = tmp_path / "vault.json"
+    monkeypatch.setattr(builder, "_get_sentence_tokenizer", lambda: type("T", (), {"tokenize": lambda _, text: [text]})())
+    monkeypatch.setattr(builder, "Pool", lambda *_: type("P", (), {"__enter__": lambda s: s, "__exit__": lambda *a: None, "imap": lambda s, fn, values: map(fn, values)})())
+    monkeypatch.setattr(builder, "tqdm", lambda values, **_: values)
+    builder.convert_html_to_json(source, vault); first = load_vault(vault)
+    builder.convert_html_to_json(source, vault); assert load_vault(vault) == first
+    mtime = html.stat().st_mtime; html.write_text("<p>second text.</p>", encoding="utf-8"); os.utime(html, (mtime, mtime))
+    builder.convert_html_to_json(source, vault); changed = load_vault(vault)
+    assert len(changed) == 1 and changed[0]["content_hash"] != first[0]["content_hash"]
+
+
+def test_builder_import_is_side_effect_free(tmp_path):
+    fake_root = tmp_path / "fake"
+    fake = fake_root / "nltk"; fake.mkdir(parents=True)
+    (fake / "__init__.py").write_text("from . import data\ndef download(*a, **k): raise AssertionError('download')\n", encoding="utf-8")
+    (fake / "data.py").write_text("def load(*a, **k): raise AssertionError('load')\n", encoding="utf-8")
+    env = os.environ | {"PYTHONPATH": str(fake_root) + os.pathsep + str(Path.cwd()), "PYTHONDONTWRITEBYTECODE": "1"}
+    result = subprocess.run([sys.executable, "-c", "import Vault_json_creation_from_HTMLs"], cwd=tmp_path, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "vault.json").exists()
+
+
+def test_owned_writer_has_no_append_mode():
+    for name in ("vault_store.py", "Vault_json_creation_from_HTMLs.py"):
+        tree = ast.parse(Path(name).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                callee = node.func.id if isinstance(node.func, ast.Name) else node.func.attr if isinstance(node.func, ast.Attribute) else ""
+                if callee in {"open", "NamedTemporaryFile"}:
+                    modes = [arg.value for arg in node.args[1:2] if isinstance(arg, ast.Constant)]
+                    modes += [keyword.value.value for keyword in node.keywords if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant)]
+                    assert all("a" not in str(mode) for mode in modes)
+    source = Path("vault_store.py").read_text(encoding="utf-8")
+    assert source.count("os.replace(") == 1

--- a/tests/test_vault_store.py
+++ b/tests/test_vault_store.py
@@ -109,14 +109,25 @@ def test_schema_backward_compatibility_and_invalid_in_memory_data(tmp_path):
     legacy = [_entry(content_hash=None, extra="ok")]
     atomic_write_json(tmp_path / "legacy.json", legacy)
     assert load_vault(tmp_path / "legacy.json") == legacy
+    compatible = [_entry(
+        entry_unknown={"nested": [1, {"value": "ok"}]},
+        chunks=[{"id": HASH_A, "text": "text", "chunk_unknown": {"nested": [True, None]}}],
+    )]
+    compatible_path = tmp_path / "compatible.json"
+    atomic_write_json(compatible_path, compatible)
+    assert load_vault(compatible_path) == compatible
     invalids = [
         {},
         ["entry"],
         [{"file_name": "", "modification_time": 1, "chunks": []}],
+        [{"file_name": "a", "chunks": []}],
+        [{"file_name": "a", "modification_time": 1}],
         [{"file_name": "a", "modification_time": True, "chunks": []}],
         [{"file_name": "a", "modification_time": float("nan"), "chunks": []}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [], "unknown": {"nested": float("inf")}}],
         [{"file_name": "a", "modification_time": 1, "chunks": ["chunk"]}],
         [{"file_name": "a", "modification_time": 1, "chunks": [{"id": "x", "text": "x"}]}],
+        [{"file_name": "a", "modification_time": 1, "chunks": [{"id": HASH_A, "text": "x", "unknown": {1: "bad"}}]}],
         [{"file_name": "a", "modification_time": 1, "chunks": [], "content_hash": "x"}],
         [{"file_name": "a", "modification_time": 1, "chunks": [], 1: "bad"}],
         [{"file_name": "a", "modification_time": 1, "chunks": [], "unknown": object()}],

--- a/vault_store.py
+++ b/vault_store.py
@@ -1,73 +1,167 @@
 import json
+import math
 import os
+import stat
 import tempfile
-import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
-def load_vault(path: str | Path) -> list[dict[str, Any]]:
+def _validate_vault_data(data: object) -> None:
+    def validate_value(value: object) -> None:
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("vault data contains a non-finite number")
+        if isinstance(value, dict):
+            if not all(isinstance(key, str) for key in value):
+                raise ValueError("vault object keys must be strings")
+            for nested in value.values():
+                validate_value(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                validate_value(nested)
+
+    if not isinstance(data, list):
+        raise ValueError("vault data must be a list")
+    for entry in data:
+        if not isinstance(entry, dict):
+            raise ValueError("vault entries must be objects")
+        file_name = entry.get("file_name")
+        if not isinstance(file_name, str) or not file_name:
+            raise ValueError("vault entry file_name must be a non-empty string")
+        modification_time = entry.get("modification_time")
+        if isinstance(modification_time, bool) or not isinstance(modification_time, (int, float)) or not math.isfinite(modification_time):
+            raise ValueError("vault entry modification_time must be finite")
+        chunks = entry.get("chunks")
+        if not isinstance(chunks, list):
+            raise ValueError("vault entry chunks must be a list")
+        content_hash = entry.get("content_hash")
+        if content_hash is not None and (not isinstance(content_hash, str) or len(content_hash) != 64 or any(character not in "0123456789abcdef" for character in content_hash)):
+            raise ValueError("vault entry content_hash must be a lowercase SHA-256")
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                raise ValueError("vault chunks must be objects")
+            chunk_id, text = chunk.get("id"), chunk.get("text")
+            if not isinstance(chunk_id, str) or len(chunk_id) != 64 or any(character not in "0123456789abcdef" for character in chunk_id) or not isinstance(text, str):
+                raise ValueError("vault chunks require a lowercase SHA-256 id and text")
+        validate_value(entry)
+    try:
+        json.dumps(data, allow_nan=False)
+    except (TypeError, ValueError) as error:
+        raise ValueError("vault data is not JSON serializable") from error
+
+
+def _normalized_file_identity(file_name: str) -> str:
+    if not isinstance(file_name, str) or not file_name:
+        raise ValueError("vault file_name must be a non-empty string")
+    return os.path.normcase(os.path.abspath(os.path.normpath(file_name)))
+
+
+def _invalid_backup_path(vault_path: Path) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    stem = f"{vault_path.name}.invalid.{timestamp}.{os.getpid()}"
+    candidate = vault_path.with_name(f"{stem}.bak")
+    counter = 1
+    while candidate.exists():
+        candidate = vault_path.with_name(f"{stem}.{counter}.bak")
+        counter += 1
+    return candidate
+
+
+def load_vault(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
     vault_path = Path(path)
     if not vault_path.exists() or vault_path.stat().st_size == 0:
         return []
-
     try:
         with vault_path.open("r", encoding="utf-8") as handle:
             data = json.load(handle)
-    except json.JSONDecodeError:
-        backup_name = (
-            f"{vault_path.name}.invalid.{int(time.time())}.bak"
-        )
-        backup_path = vault_path.with_name(backup_name)
-        os.replace(vault_path, backup_path)
+        _validate_vault_data(data)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        backup_path = _invalid_backup_path(vault_path)
+        os.rename(vault_path, backup_path)
         print(f"Invalid vault JSON moved to backup: {backup_path}")
         return []
-
-    if isinstance(data, list):
-        return data
-
-    print(f"Vault JSON is not a list in {vault_path}; starting with empty list.")
-    return []
+    return data
 
 
 def merge_vault_entries(
     existing_entries: list[dict[str, Any]],
     new_entries: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    merged: dict[str, dict[str, Any]] = {}
-
+    _validate_vault_data(existing_entries)
+    _validate_vault_data(new_entries)
+    merged: list[dict[str, Any]] = []
+    positions: dict[str, int] = {}
     for entry in existing_entries:
-        file_name = entry.get("file_name")
-        if file_name:
-            merged[os.path.normpath(file_name)] = entry
-
+        identity = _normalized_file_identity(entry["file_name"])
+        if identity in positions:
+            merged[positions[identity]] = entry
+        else:
+            positions[identity] = len(merged)
+            merged.append(entry)
+    incoming: list[tuple[str, dict[str, Any]]] = []
+    incoming_positions: dict[str, int] = {}
     for entry in new_entries:
-        file_name = entry.get("file_name")
-        if not file_name:
+        identity = _normalized_file_identity(entry["file_name"])
+        if identity in incoming_positions:
+            incoming[incoming_positions[identity]] = (identity, entry)
+        else:
+            incoming_positions[identity] = len(incoming)
+            incoming.append((identity, entry))
+    for identity, entry in incoming:
+        position = positions.get(identity)
+        if position is None:
+            positions[identity] = len(merged)
+            merged.append(entry)
             continue
-        norm_file = os.path.normpath(file_name)
-        existing = merged.get(norm_file)
-        if not existing or existing.get("modification_time") != entry.get(
-            "modification_time"
+        existing = merged[position]
+        old_hash = existing.get("content_hash")
+        new_hash = entry.get("content_hash")
+        if existing["modification_time"] == entry["modification_time"] and (
+            old_hash == new_hash or (old_hash is not None and new_hash is None)
         ):
-            merged[norm_file] = entry
+            continue
+        replacement = {key: value for key, value in existing.items() if key not in {"file_name", "modification_time", "chunks", "content_hash"}}
+        replacement.update(entry)
+        merged[position] = replacement
+    return merged
 
-    return list(merged.values())
 
-
-def atomic_write_json(path: str | Path, data: Any) -> None:
+def atomic_write_json(path: str | os.PathLike[str], data: list[dict[str, Any]]) -> None:
+    _validate_vault_data(data)
     vault_path = Path(path)
     vault_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=vault_path.parent,
-        delete=False,
-        suffix=".tmp",
-    ) as handle:
-        json.dump(data, handle, indent=2)
-        handle.flush()
+    saved_mode = stat.S_IMODE(vault_path.stat().st_mode) if vault_path.exists() else None
+    handle = None
+    temp_path: Path | None = None
+    try:
+        handle = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", newline="\n", prefix=f".{vault_path.name}.",
+            suffix=".tmp", dir=vault_path.parent, delete=False,
+        )
         temp_path = Path(handle.name)
-
-    os.replace(temp_path, vault_path)
+        json.dump(data, handle, ensure_ascii=False, allow_nan=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        handle.close()
+        handle = None
+        if saved_mode is not None:
+            os.chmod(temp_path, saved_mode)
+        os.replace(temp_path, vault_path)
+        temp_path = None
+    except BaseException as error:
+        notes: list[str] = []
+        if handle is not None:
+            try:
+                handle.close()
+            except BaseException as cleanup_error:
+                notes.append(f"temp close cleanup failed: {cleanup_error!r}")
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except BaseException as cleanup_error:
+                notes.append(f"residual temp path {temp_path}: cleanup failed: {cleanup_error!r}")
+        for note in notes:
+            error.add_note(note)
+        raise


### PR DESCRIPTION
## Outcome
Fixes #15 by replacing append-based vault persistence with validated, deterministic same-directory atomic replacement and by updating the maintained HTML vault builder to use that path.

Canonical scope:
- [Issue #15 plan](https://github.com/sriharshaguthikonda/easy-local-rag/blob/main/docs/issues/ISSUE-015-atomic-vault-write.md)
- [Decision-complete JIT packet](https://github.com/sriharshaguthikonda/easy-local-rag/blob/main/docs/superpowers/plans/2026-07-24-issue-015-atomic-vault-write-implementation.md)
- Activation: PR #35, merge `ca1af851cbb9da99137dc7ff677e06ef60303d84`

## Frozen lineage
- Base/target head: `619365224f6db3770d3369fd84a295589699e513`
- Final reviewed code head: `3ced61bcb9957907cc568e2e2560edd6f3c53b83`
- Test commit: `fb4aaf4e213bf9e2d10e691a8709efc00fd64585`
- Production commit: `45a4acfcf0d4689633438b381ed7106c7c3fd535`
- Eleven accepted-finding fix commits are preserved individually after production.

## Evidence
- Python: 3.11.9
- Pristine focused: 4 passed
- RED replay on frozen production: 17 collected, exact 4 passed / 13 failed
- Final focused: 17 passed
- Compile: PASS
- Append-mode grep: exit 1, no output (expected)
- `git diff --check`: PASS
- Full suite: only the unchanged frozen-baseline missing-PyQt5 collection errors in `tests/test_gui_settings.py` and `tests/test_rag_gui_comprehensive.py`
- Independent GSD code reviewer: PASS on exact final head

## Merge constraint
Use GitHub **Create a merge commit** only. Do not squash or rebase: the exact test, production, and per-finding child SHAs are closure and rollback evidence. Re-check that the target remains at the frozen base before merge.

#8 remains open and receives no closure credit from this PR.