### PR TITLE
docs(#37): lock ledger validator packet

### DIFF
--- a/docs/issues/ISSUE-037-ledger-sync.md
+++ b/docs/issues/ISSUE-037-ledger-sync.md
@@ -28,8 +28,10 @@ credentials or GitHub tokens.
 The validator compares the live issue state for every tracked row, enforces
 exactly one active issue, verifies referenced merged PR merge SHAs, verifies
 branch-tip SHAs whenever a document uses them as an execution gate, and rejects
-known stale lifecycle phrases including `future activation merge`. It rejects a
-ledger missing #37 or #38. Deterministic tests mock the GitHub snapshot; no
+known stale lifecycle phrases including `future activation merge`. It reads
+both the roadmap and every `docs/issues/ISSUE-*.md` canonical file, so stale
+status/lifecycle text cannot hide outside the index. It rejects a ledger
+missing #37 or #38. Deterministic tests mock the GitHub snapshot; no
 network-dependent CI gate is added.
 
 ## Required implementation sequence
@@ -56,8 +58,9 @@ network-dependent CI gate is added.
 ## Required test cases and closure gate
 
 Mocked snapshots must fail for: stale issue state, stale merged PR SHA, stale
-branch tip, duplicate active issue, missing #37/#38, and obsolete activation
-wording. A reconciled snapshot and the final live state must pass. Run focused
+branch tip, duplicate active issue, missing #37/#38, obsolete activation
+wording, and stale lifecycle/status wording in a named canonical
+`ISSUE-015-*.md` fixture. A reconciled snapshot and the final live state must pass. Run focused
 tests, affected-file compilation, `git diff --check`, and the full suite,
 comparing full-suite failures with a freshly recorded pristine baseline.
 

--- a/docs/issues/ISSUE-037-ledger-sync.md
+++ b/docs/issues/ISSUE-037-ledger-sync.md
@@ -65,10 +65,14 @@ wording, and stale lifecycle/status wording in a named canonical
 tests, affected-file compilation, `git diff --check`, and the full suite,
 comparing full-suite failures with a freshly recorded pristine baseline.
 
-`AGENTS.md` must document the command as mandatory immediately before every
-activation and closure. After implementation merge, post SHA-bound review and
-verifier evidence, close #37 with `COMPLETED`, make a small closure-ledger PR,
-and run the live validator again. Roll back the implementation with
+The later implementation-owned `AGENTS.md` edit must name the root orchestrator
+as owner: immediately after every activation, implementation merge, issue
+closure, branch archive, or PR disposition change, the root orchestrator
+updates the ledger and runs the validator before any next activation or
+closure. The command is mandatory immediately before every activation and
+closure. After implementation merge, post SHA-bound review and verifier
+evidence, close #37 with `COMPLETED`, make a small closure-ledger PR, and run
+the live validator again. Roll back the implementation with
 `git revert -m 1 <merge-sha>`; before merge, revert child commits in reverse
 order. No issue is closed without packet, implementation PR/commits, review,
 verifier, merge, rollback, and final-ledger evidence.

--- a/docs/issues/ISSUE-037-ledger-sync.md
+++ b/docs/issues/ISSUE-037-ledger-sync.md
@@ -25,8 +25,9 @@ consistent, `1` means one or more ledger mismatches, and `2` means bad usage,
 missing `gh`, authentication, or GitHub API failure. It must never print
 credentials or GitHub tokens.
 
-The validator compares the live issue state for every tracked row, enforces
-exactly one active issue, verifies each referenced PR's open/closed/merged
+The validator compares the live issue state for every tracked row, enforces at
+most one active issue (the declared activated issue is sole active; stable
+between-issues/after-closure state may have zero), verifies each referenced PR's open/closed/merged
 disposition and requires its merge SHA exactly when it is merged, verifies
 branch-tip SHAs whenever a document uses them as an execution gate, and rejects
 known stale lifecycle phrases including `future activation merge`. It reads
@@ -61,7 +62,8 @@ network-dependent CI gate is added.
 Mocked snapshots must fail for: stale issue state, stale merged PR SHA, stale
 branch tip, a closed-unmerged PR #1-style disposition, duplicate active issue, missing #37/#38, obsolete activation
 wording, and stale lifecycle/status wording in a named canonical
-`ISSUE-015-*.md` fixture. A reconciled snapshot and the final live state must pass. Run focused
+`ISSUE-015-*.md` fixture. Reconciled fixtures must pass for both zero-active
+between-issues state and one declared active issue. Run focused
 tests, affected-file compilation, `git diff --check`, and the full suite,
 comparing full-suite failures with a freshly recorded pristine baseline.
 

--- a/docs/issues/ISSUE-037-ledger-sync.md
+++ b/docs/issues/ISSUE-037-ledger-sync.md
@@ -26,7 +26,8 @@ missing `gh`, authentication, or GitHub API failure. It must never print
 credentials or GitHub tokens.
 
 The validator compares the live issue state for every tracked row, enforces
-exactly one active issue, verifies referenced merged PR merge SHAs, verifies
+exactly one active issue, verifies each referenced PR's open/closed/merged
+disposition and requires its merge SHA exactly when it is merged, verifies
 branch-tip SHAs whenever a document uses them as an execution gate, and rejects
 known stale lifecycle phrases including `future activation merge`. It reads
 both the roadmap and every `docs/issues/ISSUE-*.md` canonical file, so stale
@@ -58,7 +59,7 @@ network-dependent CI gate is added.
 ## Required test cases and closure gate
 
 Mocked snapshots must fail for: stale issue state, stale merged PR SHA, stale
-branch tip, duplicate active issue, missing #37/#38, obsolete activation
+branch tip, a closed-unmerged PR #1-style disposition, duplicate active issue, missing #37/#38, obsolete activation
 wording, and stale lifecycle/status wording in a named canonical
 `ISSUE-015-*.md` fixture. A reconciled snapshot and the final live state must pass. Run focused
 tests, affected-file compilation, `git diff --check`, and the full suite,

--- a/docs/issues/ISSUE-037-ledger-sync.md
+++ b/docs/issues/ISSUE-037-ledger-sync.md
@@ -1,0 +1,70 @@
+# Issue #37: Keep the canonical ledger synchronized with live GitHub state
+
+[Roadmap ledger](README.md) · [implementation packet](../superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md)
+
+**Status:** PLANNING — documentation packet only; a separate activation merge
+must first reconcile the known #8/#15, branch-inventory, and lifecycle drift.
+**GitHub:** https://github.com/sriharshaguthikonda/easy-local-rag/issues/37
+**Labels / priority:** `priority:P1`, `type:dx`
+**Dependencies:** #2 remains `blocked-awaiting-user`. #38 is the only approved
+independent P0 exception after #37; it does not unlock or bypass #2 -> #18 ->
+#26.
+
+## Maintained contract
+
+Add `scripts/validate_issue_ledger.py`, using Python stdlib and the existing
+`gh` CLI only. Its public command is:
+
+```powershell
+python scripts/validate_issue_ledger.py --repo OWNER/REPO
+```
+
+It defaults to `docs/issues/README.md` and `docs/plans/branch-inventory.md`.
+It prints only identifiers and expected/actual lifecycle data: exit `0` means
+consistent, `1` means one or more ledger mismatches, and `2` means bad usage,
+missing `gh`, authentication, or GitHub API failure. It must never print
+credentials or GitHub tokens.
+
+The validator compares the live issue state for every tracked row, enforces
+exactly one active issue, verifies referenced merged PR merge SHAs, verifies
+branch-tip SHAs whenever a document uses them as an execution gate, and rejects
+known stale lifecycle phrases including `future activation merge`. It rejects a
+ledger missing #37 or #38. Deterministic tests mock the GitHub snapshot; no
+network-dependent CI gate is added.
+
+## Required implementation sequence
+
+1. Merge this reviewed packet, then a distinct activation merge that records
+   #8/#15 closure, PR #36 merge `88d0758ce1ffe6d61dd3ed99c0c5558e1bb8f205`,
+   current branch/PR state, #37 as the sole active issue, #38 queued, and #2
+   blocked. That activation merge alone owns obsolete lifecycle wording.
+2. Create a clean implementation worktree from its fetched, frozen target SHA.
+   Record pristine baseline first. The current `main` packet base
+   `ca1af851cbb9da99137dc7ff677e06ef60303d84` has no `tests/` directory and no
+   `streamlit_app.py`, `rag_gui.py`, or `GUI_direct_search.py`; the recorded
+   baseline `python -m pytest tests -q` therefore exits 4 and compilation has
+   no targets. Re-measure on the activated target; do not treat this as a pass.
+3. Commit a failing mocked-validator test change only as
+   `test(#37): specify issue ledger validation`, then production GREEN only as
+   `fix(#37): validate canonical issue ledger`. Each accepted review finding is
+   one small `fix(#37): address accepted review finding` commit.
+4. Require exact-head re-review and an independent verifier. Immediately before
+   a GitHub **Create a merge commit**, refetch the frozen target and stop on any
+   SHA change. Never squash or rebase away the test, production, or accepted
+   finding commits.
+
+## Required test cases and closure gate
+
+Mocked snapshots must fail for: stale issue state, stale merged PR SHA, stale
+branch tip, duplicate active issue, missing #37/#38, and obsolete activation
+wording. A reconciled snapshot and the final live state must pass. Run focused
+tests, affected-file compilation, `git diff --check`, and the full suite,
+comparing full-suite failures with a freshly recorded pristine baseline.
+
+`AGENTS.md` must document the command as mandatory immediately before every
+activation and closure. After implementation merge, post SHA-bound review and
+verifier evidence, close #37 with `COMPLETED`, make a small closure-ledger PR,
+and run the live validator again. Roll back the implementation with
+`git revert -m 1 <merge-sha>`; before merge, revert child commits in reverse
+order. No issue is closed without packet, implementation PR/commits, review,
+verifier, merge, rollback, and final-ledger evidence.

--- a/docs/issues/ISSUE-038-streamlit-evidence-contract.md
+++ b/docs/issues/ISSUE-038-streamlit-evidence-contract.md
@@ -1,0 +1,38 @@
+# Issue #38: Preserve retrieved evidence through the Streamlit model prompt
+
+[Roadmap ledger](README.md)
+
+**Status:** QUEUED — no JIT implementation packet exists until #37 closes.
+**GitHub:** https://github.com/sriharshaguthikonda/easy-local-rag/issues/38
+**Labels / priority:** `priority:P0`, `type:bug`
+**Dependencies:** Explicit independent P0 exception after #37 only. #2 stays
+blocked and #38 neither unlocks nor bypasses the #2 -> #18 -> #26 sequence.
+
+## Canonical acceptance contract
+
+Freeze a clean worktree at the live GUI branch tip; do not merge `main` into
+that GUI lineage. Preserve `get_relevant_context_hybrid(...) -> tuple[str,
+list[dict]]`, but make every returned source retain non-empty retrieved
+`document`, `file_name`, `score`, and existing safe metadata. Derive the legacy
+joined context from that one ordered source list.
+
+`build_numbered_sources()` must preserve source order and text while adding
+sequential `citation_id` and `source_name`. `build_guarded_context_block()`
+must reject missing/empty text before either provider is called. Remove the
+`"Answer this yourself!"` retrieval fallback: retrieval failure visibly
+abstains/errors without a model call. Unknown `[N]` citation IDs visibly fail
+validation and are never silently accepted.
+
+The same source contract applies to Standard, Focused Search, Brain Dump, and
+Summary modes. A later packet must prove: one unique sentinel enters the model
+prompt exactly once; two chunks keep text-to-citation mapping; all four modes
+share the contract; empty text prevents provider calls; joined context equals
+the structured sources; and invented citations fail validation.
+
+## Closure gate
+
+After a decision-complete #38 packet, use pristine/RED/GREEN commits, exact-head
+review, independent verification, a frozen-target guard, and Create-a-merge-
+commit merging. Then #5 may receive a verification-only audit; #7 and #12 may
+receive their specified fresh/recovery smokes. Any audit needing code or new
+tests remains open behind #2.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,10 +1,12 @@
 # Canonical issue-plan index
 
 This index is the authoritative issue/plan/status index and roadmap ledger for
-the 24 tracked issues:
+the 26 tracked issues:
 [#2](https://github.com/sriharshaguthikonda/easy-local-rag/issues/2) and
 [#5](https://github.com/sriharshaguthikonda/easy-local-rag/issues/5) through
-[#27](https://github.com/sriharshaguthikonda/easy-local-rag/issues/27).
+[#27](https://github.com/sriharshaguthikonda/easy-local-rag/issues/27), plus
+[#37](https://github.com/sriharshaguthikonda/easy-local-rag/issues/37) and
+[#38](https://github.com/sriharshaguthikonda/easy-local-rag/issues/38).
 Canonical issue files are acceptance contracts, not implementation evidence.
 Authority precedence is: **GitHub issue = live state and human decisions;
 canonical plan = scope, invariants, and closure gates; roadmap ledger =
@@ -16,7 +18,7 @@ and #14 is closed as a duplicate.
 
 ## Required execution order
 
-`#2A -> #18 -> #26A -> separately approved #26B -> #2 closure -> #19A -> #19B -> #20A -> .memory #4 handoff -> #20B -> .memory #5 handoff -> #21A -> #22A -> #23 -> #21B -> #22B -> #24 specification -> #27 -> #25 -> GUI/no-GUI handoff -> #26C -> #26D`
+`#37 -> #38 (independent P0 exception) -> verification-only #5/#7/#12 audits -> #2A -> #18 -> #26A -> separately approved #26B -> #2 closure -> #19A -> #19B -> #20A -> .memory #4 handoff -> #20B -> .memory #5 handoff -> #21A -> #22A -> #23 -> #21B -> #22B -> #24 specification -> #27 -> #25 -> GUI/no-GUI handoff -> #26C -> #26D`
 
 #24 is a specification-only issue. It records the future GUI contract and
 salvage decisions; it does not authorize GUI implementation. #17 is an epic,
@@ -51,6 +53,8 @@ unresolved placeholder, implementer choice, or speculative dependency.
 | #2 | blocked-awaiting-user | Await user rotation evidence; no containment closure is inferred from docs. |
 | #9 | closed | Completed through [PR #33](https://github.com/sriharshaguthikonda/easy-local-rag/pull/33), merged as `619365224f6db3770d3369fd84a295589699e513`; [Issue #9](https://github.com/sriharshaguthikonda/easy-local-rag/issues/9) is closed. |
 | #15 | active | [2026-07-24 atomic-vault implementation packet](../superpowers/plans/2026-07-24-issue-015-atomic-vault-write-implementation.md) completed final review at `14df1b7fcea0775c56b6a774c4047c3f14e29c9d` and merged as immutable docs evidence `61fdb3b30d19451fd47b38c618c8d34630b8f547`. Code work remains gated on this activation PR's future GitHub merge commit SHA. |
+| #37 | planning | [Ledger synchronization](ISSUE-037-ledger-sync.md) · [implementation packet](../superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md). This packet does not reconcile existing lifecycle drift; a separate activation PR owns that state transition. |
+| #38 | queued | [Streamlit evidence contract](ISSUE-038-streamlit-evidence-contract.md). Explicit independent P0 exception after #37 only; #2 remains blocked. |
 | Active issue | #15 | #15 is the sole active issue. Code work remains gated on this activation PR's future GitHub merge commit SHA. |
 
 Workers use this lifecycle exactly: `planner packet -> ChatGPT review -> GSD checker ->
@@ -167,6 +171,8 @@ approval, rollback, or scope means a separate packet.
 | #25 | P0 todo | Open — cutover/retirement gate | [Chroma retirement](ISSUE-025-chroma-retirement.md) | After #27 and all migration/client gates; final state creates the blocked GUI issue or records no-GUI, then unlocks late #26. | [Issue #25](https://github.com/sriharshaguthikonda/easy-local-rag/issues/25) |
 | #26 | P1 developer experience | Open — split early/late | [Repository cleanup](ISSUE-026-repo-cleanup.md) | 26A/26B follow #2 containment/#18 and close #2 before #19; 26C/26D consume #25's immutable GUI/no-GUI handoff. | [Issue #26](https://github.com/sriharshaguthikonda/easy-local-rag/issues/26) |
 | #27 | P0 security | Open — answer-safety gate | [Grounded answers](ISSUE-027-grounded-answers.md) | Extends #5/#13 and owns structured validation associated with closed duplicate #14; after #24 and #21B/#22B, before #25. | [Issue #27](https://github.com/sriharshaguthikonda/easy-local-rag/issues/27) |
+| #37 | P1 developer experience | Open — planning | [Ledger synchronization](ISSUE-037-ledger-sync.md) | First: repairs the authoritative execution ledger. [Implementation packet](../superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md) is documentation only until separate activation. | [Issue #37](https://github.com/sriharshaguthikonda/easy-local-rag/issues/37) |
+| #38 | P0 bug | Open — queued independent exception | [Streamlit evidence contract](ISSUE-038-streamlit-evidence-contract.md) | After #37 only; it does not unlock or bypass #2 -> #18 -> #26. | [Issue #38](https://github.com/sriharshaguthikonda/easy-local-rag/issues/38) |
 
 ## Gate discipline
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -32,9 +32,10 @@ Only the next unblocked packet may be created, at
 `docs/superpowers/plans/YYYY-MM-DD-issue-NNN-<slug>-implementation.md`.
 Each packet names one canonical issue/slice and its canonical plan links to it
 once created; this ledger tracks its state. The only states are `queued`,
-`planning`, `active`, `review`, `blocked-awaiting-user`, and `closed`. Exactly
-one issue may be `active` at a time (zero only between packets or while
-approvals block execution). A blocked-awaiting-user #2 parks #2; execute #9,
+`planning`, `active`, `review`, `blocked-awaiting-user`, and `closed`. At most
+one issue may be `active`: an activated issue is the declared sole active
+issue, while stable between-issues/after-closure states may have zero. A
+blocked-awaiting-user #2 parks #2; execute #9,
 then #15, one at a time, without advancing #18 or #26. If both close and #2
 remains blocked, only read-only JIT packet preparation may continue; do not
 bypass the #2/#18/#26 security sequence.

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -17,7 +17,8 @@ and optional document-path overrides, defaults to `docs/issues/README.md` and
 `2` usage/API/CLI/auth failure. Output names identifiers and expected/actual
 state only; never secrets.
 
-Parse the canonical tracked-issue rows and lifecycle text, obtain one live
+Parse the canonical tracked-issue rows and lifecycle text from both
+`docs/issues/README.md` and every `docs/issues/ISSUE-*.md`, obtain one live
 snapshot through `gh` JSON output, and compare: issue open/closed state; the
 single-active invariant; every referenced merged PR SHA; every branch tip used
 as an execution gate; presence of #37/#38; and stale phrases such as `future
@@ -47,8 +48,9 @@ while `git diff --check` exited 0. Re-run and record this exact comparison on
 the activated target.
 
 First add deterministic mocked-snapshot tests and record RED for stale issue,
-stale PR SHA, stale branch tip, duplicate active, absent #37/#38, and obsolete
-activation wording; commit only those tests as:
+stale PR SHA, stale branch tip, duplicate active, absent #37/#38, obsolete
+activation wording, and stale status/lifecycle wording in a named canonical
+`ISSUE-015-*.md` fixture; commit only those tests as:
 
 ```text
 test(#37): specify issue ledger validation

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -89,6 +89,21 @@ activation wording, and stale status/lifecycle wording in a named canonical
 test(#37): specify issue ledger validation
 ```
 
+The test path is exactly `tests/test_validate_issue_ledger.py`. RED runs
+`python -m pytest tests/test_validate_issue_ledger.py -q` and must exit nonzero
+with the new requirements failing before production exists. After production,
+GREEN reruns that exact command and must exit 0. Then run:
+
+```powershell
+python -m py_compile scripts/validate_issue_ledger.py tests/test_validate_issue_ledger.py
+git diff --check
+python -m pytest tests -q
+```
+
+Compilation and diff checks must exit 0. Compare the full-suite exit code and
+failure IDs to the freshly recorded activated-target pristine baseline; any new
+failure is a stop, not historical acceptance.
+
 Implement the minimal parser/CLI and record GREEN for each failing case plus a
 reconciled fixture; commit only production as:
 

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -55,7 +55,7 @@ credentials are accepted, stored, or printed.
 
 ## Frozen activation and ownership
 
-The separate activation PR is the first code gate. It owns only the canonical
+The separate activation PR is the first implementation precondition. It owns only the canonical
 ledger/plan rows necessary to record #8 and #15 closed, PR #36 merge
 `88d0758ce1ffe6d61dd3ed99c0c5558e1bb8f205`, refreshed main/GUI/PR #1 state,
 removal of obsolete future-activation wording, #37 as sole active, #38 queued,

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -37,8 +37,12 @@ it changes before work or merge. Do not merge `main` into the later #38 GUI
 lineage.
 
 The implementation branch owns `scripts/validate_issue_ledger.py`, its focused
-tests, and the required `AGENTS.md` command. It must not alter #38 code,
-credential history, generated data, or unrelated ledger state.
+tests, and the required `AGENTS.md` wording. That wording names the root
+orchestrator as the lifecycle owner: after activation, implementation merge,
+issue closure, branch archive, or PR disposition change, update the ledger and
+run the validator immediately, before the next activation or closure. It must
+not alter #38 code, credential history, generated data, or unrelated ledger
+state.
 
 ## TDD and evidence
 

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -20,7 +20,8 @@ state only; never secrets.
 Parse the canonical tracked-issue rows and lifecycle text from both
 `docs/issues/README.md` and every `docs/issues/ISSUE-*.md`, obtain one live
 snapshot through `gh` JSON output, and compare: issue open/closed state; the
-single-active invariant; every referenced PR state/disposition and merge SHA
+at-most-one-active invariant (exactly the declared active issue when activated,
+zero allowed between issues/after closure); every referenced PR state/disposition and merge SHA
 only when that PR is merged; every branch tip used as an execution gate;
 presence of #37/#38; and stale phrases such as `future
 activation merge`. Keep parsing intentionally narrow to the documented ledger
@@ -83,7 +84,8 @@ First add deterministic mocked-snapshot tests and record RED for stale issue,
 stale PR SHA, a closed-unmerged PR #1-style disposition, stale branch tip,
 duplicate active, absent #37/#38, obsolete
 activation wording, and stale status/lifecycle wording in a named canonical
-`ISSUE-015-*.md` fixture; commit only those tests as:
+`ISSUE-015-*.md` fixture. Reconciled fixtures include zero-active and exactly
+one declared-active cases; commit only those tests as:
 
 ```text
 test(#37): specify issue ledger validation

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -11,9 +11,9 @@ the already-known #8/#15 drift, or weaken #2's blocking sequence.
 Add only `scripts/validate_issue_ledger.py`, focused deterministic tests, and
 the mandatory command wording in `AGENTS.md` during the later implementation
 PR. Use only Python stdlib and existing `gh`; no dependency, CI network gate,
-or GitHub mutation is allowed. The CLI accepts required `--repo OWNER/REPO`
-and optional document-path overrides, defaults to `docs/issues/README.md` and
-`docs/plans/branch-inventory.md`, and returns: `0` consistent, `1` mismatch,
+or GitHub mutation is allowed. The CLI accepts only required `--repo OWNER/REPO`,
+uses `docs/issues/README.md` and `docs/plans/branch-inventory.md` defaults, and
+returns: `0` consistent, `1` mismatch,
 `2` usage/API/CLI/auth failure. Output names identifiers and expected/actual
 state only; never secrets.
 

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -26,6 +26,33 @@ presence of #37/#38; and stale phrases such as `future
 activation merge`. Keep parsing intentionally narrow to the documented ledger
 forms; an unparseable required row is a mismatch, not a false pass.
 
+## Normalized snapshot seam
+
+The internal validation seam accepts parsed ledger text, a mapping of canonical
+`ISSUE-*.md` texts, inventory text, and this normalized JSON-shaped snapshot:
+
+```json
+{
+  "issues": {"37": {"state": "OPEN"}},
+  "pull_requests": {"36": {"state": "MERGED", "merge_sha": "40-hex"}, "1": {"state": "CLOSED", "merge_sha": null}},
+  "branches": {"main": "40-hex"}
+}
+```
+
+Tests inject that seam directly with parsed text or temporary fixtures; no
+additional public CLI flag exists. The live collector obtains only this data:
+
+```powershell
+gh issue list --repo OWNER/REPO --state all --limit 100 --json number,state
+gh pr list --repo OWNER/REPO --state all --limit 100 --json number,state,mergeCommit
+gh api repos/OWNER/REPO/git/ref/heads/BRANCH
+```
+
+The final command is run once for each branch named as an execution gate. Parse
+`mergeCommit.oid` and the ref object's SHA into the normalized fields. Command
+arguments, JSON, and diagnostics contain identifiers/states/SHAs only; no
+credentials are accepted, stored, or printed.
+
 ## Frozen activation and ownership
 
 The separate activation PR is the first code gate. It owns only the canonical

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -20,8 +20,9 @@ state only; never secrets.
 Parse the canonical tracked-issue rows and lifecycle text from both
 `docs/issues/README.md` and every `docs/issues/ISSUE-*.md`, obtain one live
 snapshot through `gh` JSON output, and compare: issue open/closed state; the
-single-active invariant; every referenced merged PR SHA; every branch tip used
-as an execution gate; presence of #37/#38; and stale phrases such as `future
+single-active invariant; every referenced PR state/disposition and merge SHA
+only when that PR is merged; every branch tip used as an execution gate;
+presence of #37/#38; and stale phrases such as `future
 activation merge`. Keep parsing intentionally narrow to the documented ledger
 forms; an unparseable required row is a mismatch, not a false pass.
 
@@ -48,7 +49,8 @@ while `git diff --check` exited 0. Re-run and record this exact comparison on
 the activated target.
 
 First add deterministic mocked-snapshot tests and record RED for stale issue,
-stale PR SHA, stale branch tip, duplicate active, absent #37/#38, obsolete
+stale PR SHA, a closed-unmerged PR #1-style disposition, stale branch tip,
+duplicate active, absent #37/#38, obsolete
 activation wording, and stale status/lifecycle wording in a named canonical
 `ISSUE-015-*.md` fixture; commit only those tests as:
 

--- a/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
+++ b/docs/superpowers/plans/2026-07-27-issue-037-ledger-validator-implementation.md
@@ -1,0 +1,77 @@
+# Issue #37 Ledger Validator Implementation Packet
+
+[GitHub issue #37](https://github.com/sriharshaguthikonda/easy-local-rag/issues/37) · [canonical plan](../../issues/ISSUE-037-ledger-sync.md) · [roadmap ledger](../../issues/README.md)
+
+**Packet base:** `origin/main` at `ca1af851cbb9da99137dc7ff677e06ef60303d84`.
+This packet is immutable implementation detail: it cannot activate #37, repair
+the already-known #8/#15 drift, or weaken #2's blocking sequence.
+
+## Locked scope
+
+Add only `scripts/validate_issue_ledger.py`, focused deterministic tests, and
+the mandatory command wording in `AGENTS.md` during the later implementation
+PR. Use only Python stdlib and existing `gh`; no dependency, CI network gate,
+or GitHub mutation is allowed. The CLI accepts required `--repo OWNER/REPO`
+and optional document-path overrides, defaults to `docs/issues/README.md` and
+`docs/plans/branch-inventory.md`, and returns: `0` consistent, `1` mismatch,
+`2` usage/API/CLI/auth failure. Output names identifiers and expected/actual
+state only; never secrets.
+
+Parse the canonical tracked-issue rows and lifecycle text, obtain one live
+snapshot through `gh` JSON output, and compare: issue open/closed state; the
+single-active invariant; every referenced merged PR SHA; every branch tip used
+as an execution gate; presence of #37/#38; and stale phrases such as `future
+activation merge`. Keep parsing intentionally narrow to the documented ledger
+forms; an unparseable required row is a mismatch, not a false pass.
+
+## Frozen activation and ownership
+
+The separate activation PR is the first code gate. It owns only the canonical
+ledger/plan rows necessary to record #8 and #15 closed, PR #36 merge
+`88d0758ce1ffe6d61dd3ed99c0c5558e1bb8f205`, refreshed main/GUI/PR #1 state,
+removal of obsolete future-activation wording, #37 as sole active, #38 queued,
+and #2 blocked. Fetch and freeze that target SHA before implementation; stop if
+it changes before work or merge. Do not merge `main` into the later #38 GUI
+lineage.
+
+The implementation branch owns `scripts/validate_issue_ledger.py`, its focused
+tests, and the required `AGENTS.md` command. It must not alter #38 code,
+credential history, generated data, or unrelated ledger state.
+
+## TDD and evidence
+
+Record a pristine baseline on the activated target before edits. The packet
+base itself has no `tests/` directory and no named GUI compile targets:
+`python -m pytest tests -q` exited 4 with `file or directory not found: tests`,
+while `git diff --check` exited 0. Re-run and record this exact comparison on
+the activated target.
+
+First add deterministic mocked-snapshot tests and record RED for stale issue,
+stale PR SHA, stale branch tip, duplicate active, absent #37/#38, and obsolete
+activation wording; commit only those tests as:
+
+```text
+test(#37): specify issue ledger validation
+```
+
+Implement the minimal parser/CLI and record GREEN for each failing case plus a
+reconciled fixture; commit only production as:
+
+```text
+fix(#37): validate canonical issue ledger
+```
+
+Run focused tests, affected-file compilation, `git diff --check`, and full
+suite comparison against pristine. Each accepted reviewer finding receives one
+small commit; rejected findings get a written disposition. The reviewer and
+independent verifier must PASS the same final SHA.
+
+## Merge, rollback, and closure
+
+Immediately before merge, refetch the implementation target and confirm the PR
+base/head match frozen evidence. Merge with GitHub **Create a merge commit**;
+never squash or rebase. Roll back after merge with `git revert -m 1 <merge-sha>`
+or, before merge, child commits in reverse order. Post the immutable packet,
+review, verifier, test, PR, commit, merge, rollback, and live-validator
+evidence; close #37 as `COMPLETED`; merge a narrow closure-ledger PR; rerun the
+live validator. Only then may #38 receive its own JIT packet.


### PR DESCRIPTION
## Summary
- add canonical plans for #37 and queued #38
- lock the stdlib + existing `gh` ledger-validator implementation packet
- preserve #2 as blocked and defer #8/#15/inventory reconciliation to a separate activation PR

## Exact review head
- `cba86f0e1f6cd2d03c6280ebda88e8714925af9a`
- GSD plan review: eight accepted findings fixed in separate commits; scoped re-review PASS
- ChatGPT advisory job `20260726T213752Z_3dd91804c5f0d71a` remains pending and is non-gating under the packet policy

## Validation
- `git diff --check ca1af851cbb9da99137dc7ff677e06ef60303d84..cba86f0e1f6cd2d03c6280ebda88e8714925af9a`
- local Markdown link targets verified
- changed paths are exactly the four packet documents

Closes no issue. #37 remains planning until the separate activation merge.