### PR TITLE
fix(#37): validate canonical issue ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Ledger validation
+
+The root orchestrator updates the canonical ledger and runs
+`python scripts/validate_issue_ledger.py --repo OWNER/REPO` immediately after
+an activation, implementation merge, issue closure, branch archive, or PR
+disposition change, and before the next activation or closure. This command is
+mandatory before every activation and closure.

--- a/docs/issues/ISSUE-009-validate-conversation-import.md
+++ b/docs/issues/ISSUE-009-validate-conversation-import.md
@@ -2,7 +2,7 @@
 
 [Roadmap ledger](README.md) · [implementation packet](../superpowers/plans/2026-07-24-issue-009-validate-conversation-import-implementation.md)
 
-**Status:** ACTIVE — [PR #31](https://github.com/sriharshaguthikonda/easy-local-rag/pull/31) merged the approved packet as `fd11bb7d706665b4094a088aaa0a97546b205135`; implementation and closure evidence remain pending.
+**Status:** CLOSED — COMPLETED on GitHub through [PR #33](https://github.com/sriharshaguthikonda/easy-local-rag/pull/33), merged as `619365224f6db3770d3369fd84a295589699e513`.
 
 **GitHub:** https://github.com/sriharshaguthikonda/easy-local-rag/issues/9
 **Priority/type:** `priority:P0`, `type:security`

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -53,8 +53,15 @@ def _canonical_status(name, text):
     number = re.fullmatch(r"ISSUE-(\d{3})-[^.]+\.md", name)
     if not number:
         return None, None
-    status = re.search(r"^\*\*Status:\*\*\s*([A-Za-z-]+)", text, re.MULTILINE)
-    return number.group(1).lstrip("0") or "0", status.group(1).upper() if status else None
+    status = re.search(r"^(?:\*\*Status:\*\*|Status:)\s*(.+)$", text, re.MULTILINE)
+    if not status:
+        return number.group(1).lstrip("0") or "0", None
+    value = status.group(1).strip().strip("*").strip()
+    lifecycle = re.match(r"(ACTIVE|PLANNING|QUEUED|REVIEW|BLOCKED-AWAITING-USER|OPEN|CLOSED)\b", value, re.IGNORECASE)
+    if lifecycle:
+        return number.group(1).lstrip("0") or "0", lifecycle.group(1).upper()
+    lifecycle = re.search(r"\b(open|closed)\b", value, re.IGNORECASE)
+    return number.group(1).lstrip("0") or "0", lifecycle.group(1).upper() if lifecycle else value.upper()
 
 
 def _inventory(inventory_text):
@@ -116,7 +123,7 @@ def validate_ledger(*, roadmap_text, issue_texts, inventory_text, snapshot):
         if status is None:
             errors.append(f"{label}: expected documented Status, actual malformed")
             continue
-        if status not in {"ACTIVE", "PLANNING", "QUEUED", "REVIEW", "BLOCKED-AWAITING-USER", "CLOSED"}:
+        if status not in {"ACTIVE", "PLANNING", "QUEUED", "REVIEW", "BLOCKED-AWAITING-USER", "OPEN", "CLOSED"}:
             errors.append(f"{label}: expected documented Status, actual {status}")
         elif number not in issues:
             errors.append(f"issue #{number}: expected {_state(status)}, actual missing")

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -21,11 +21,12 @@ def _state(value):
 
 
 def _obsolete(text):
-    match = re.search(re.escape(OBSOLETE), text, re.IGNORECASE)
-    if not match:
-        return False
-    prefix = text[max(0, match.start() - 80):match.start()].lower()
-    return "stale lifecycle phrases" not in prefix
+    for match in re.finditer(re.escape(OBSOLETE), text, re.IGNORECASE):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line = text[line_start:text.find("\n", match.start()) if "\n" in text[match.start():] else len(text)]
+        if not re.search(r"stale lifecycle phrases\s+(?:including|include)\s+`?future activation merge`?", line, re.IGNORECASE):
+            return True
+    return False
 
 
 def _roadmap_rows(text):

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -1,0 +1,206 @@
+"""Validate the canonical issue ledger against GitHub's public state."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SHA = r"[0-9a-f]{40}"
+OBSOLETE = "future activation merge"
+
+
+class LedgerCliError(Exception):
+    pass
+
+
+def _state(value):
+    return "CLOSED" if value.lower() == "closed" else "OPEN"
+
+
+def _obsolete(text):
+    match = re.search(re.escape(OBSOLETE), text, re.IGNORECASE)
+    if not match:
+        return False
+    prefix = text[max(0, match.start() - 80):match.start()].lower()
+    return "stale lifecycle phrases" not in prefix
+
+
+def _roadmap_rows(text):
+    rows = {}
+    for line in text.splitlines():
+        match = re.fullmatch(r"\|\s*#(\d+)\s*\|\s*([a-z-]+)\s*\|.*\|", line.strip())
+        if match:
+            rows[match.group(1)] = match.group(2)
+    return rows
+
+
+def _canonical_status(name, text):
+    number = re.fullmatch(r"ISSUE-(\d{3})-[^.]+\.md", name)
+    if not number:
+        return None, None
+    status = re.search(r"^\*\*Status:\*\*\s*([A-Za-z-]+)", text, re.MULTILINE)
+    return number.group(1).lstrip("0") or "0", status.group(1).upper() if status else None
+
+
+def _inventory(inventory_text):
+    branches = {}
+    for block in re.split(r"(?=^## )", inventory_text, flags=re.MULTILINE):
+        heading = re.match(r"## `([^`]+)`\s*$", block, re.MULTILINE)
+        gate = re.search(r"^[-*]\s+Execution gate tip:\s*`(" + SHA + r")`", block, re.MULTILINE)
+        if heading and gate:
+            branches[heading.group(1)] = gate.group(1)
+
+    prs = {}
+    for block in re.split(r"(?=^## PR #)", inventory_text, flags=re.MULTILINE):
+        heading = re.match(r"## PR #(\d+)\b", block)
+        if not heading:
+            continue
+        state = re.search(r"State at inspection:\s*\*\*([A-Z]+)(?:,\s*(unmerged))?\*\*", block)
+        if not state:
+            prs[heading.group(1)] = None
+            continue
+        expected = {"state": state.group(1), "merge_sha": None}
+        if expected["state"] == "MERGED":
+            sha = re.search(r"merge-commit SHA:\s*`?\s*(" + SHA + r")", block, re.IGNORECASE)
+            expected["merge_sha"] = sha.group(1) if sha else "MALFORMED"
+        elif state.group(2) != "unmerged":
+            expected["merge_sha"] = "MALFORMED"
+        prs[heading.group(1)] = expected
+    return branches, prs
+
+
+def validate_ledger(*, roadmap_text, issue_texts, inventory_text, snapshot):
+    errors = []
+    rows = _roadmap_rows(roadmap_text)
+    for number in ("37", "38"):
+        if number not in rows:
+            errors.append(f"roadmap #{number}: expected present, actual missing")
+
+    active = sorted(f"#{number}" for number, state in rows.items() if state == "active")
+    if len(active) > 1:
+        errors.append(f"active issues: expected at most one, actual {', '.join(active)}")
+    declared = re.search(r"^\|\s*Active issue\s*\|\s*(#\d+|none)\s*\|", roadmap_text, re.MULTILINE)
+    actual_active = active[0] if len(active) == 1 else "none"
+    if not declared or declared.group(1) != actual_active:
+        errors.append(f"declared active issue: expected {actual_active}, actual {declared.group(1) if declared else 'missing'}")
+    if _obsolete(roadmap_text):
+        errors.append(f"roadmap: expected no obsolete activation wording, actual {OBSOLETE}")
+
+    issues = snapshot.get("issues", {})
+    for number, lifecycle in rows.items():
+        if number not in issues:
+            errors.append(f"issue #{number}: expected {_state(lifecycle)}, actual missing")
+        elif issues[number].get("state") != _state(lifecycle):
+            errors.append(f"issue #{number}: expected {_state(lifecycle)}, actual {issues[number].get('state', 'missing')}")
+
+    for name, text in issue_texts.items():
+        number, status = _canonical_status(name, text)
+        if number is None:
+            continue
+        label = f"ISSUE-{int(number):03d}"
+        if status is None:
+            errors.append(f"{label}: expected documented Status, actual malformed")
+            continue
+        if status not in {"ACTIVE", "PLANNING", "QUEUED", "REVIEW", "BLOCKED-AWAITING-USER", "CLOSED"}:
+            errors.append(f"{label}: expected documented Status, actual {status}")
+        elif number not in issues:
+            errors.append(f"issue #{number}: expected {_state(status)}, actual missing")
+        elif issues[number].get("state") != _state(status):
+            errors.append(f"{label}: expected {_state(issues[number].get('state', 'missing'))}, actual {status}")
+        if _obsolete(text):
+            errors.append(f"{label}: expected no obsolete activation wording, actual {OBSOLETE}")
+
+    branches, prs = _inventory(inventory_text)
+    for branch, expected in branches.items():
+        actual = snapshot.get("branches", {}).get(branch, "missing")
+        if actual != expected:
+            errors.append(f"branch {branch}: expected {expected}, actual {actual}")
+    for number, expected in prs.items():
+        if expected is None or expected["merge_sha"] == "MALFORMED":
+            errors.append(f"PR #{number}: expected documented disposition, actual malformed")
+            continue
+        actual = snapshot.get("prs", {}).get(number)
+        if actual is None or actual.get("state") != expected["state"]:
+            errors.append(f"PR #{number}: expected {expected['state']}, actual {actual.get('state', 'missing') if actual else 'missing'}")
+            continue
+        actual_sha = actual.get("merge_sha") or "none"
+        expected_sha = expected["merge_sha"] or "none"
+        if actual_sha != expected_sha:
+            errors.append(f"PR #{number} merge SHA: expected {expected_sha}, actual {actual_sha}")
+    return errors
+
+
+def _run(command, runner):
+    try:
+        result = runner(command, capture_output=True, text=True)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise LedgerCliError("gh command failed") from exc
+    if result.returncode:
+        raise LedgerCliError("gh command failed")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LedgerCliError("gh returned invalid JSON") from exc
+
+
+def collect_snapshot(repo, branches, runner=subprocess.run):
+    issues = _run(["gh", "issue", "list", "--repo", repo, "--state", "all", "--limit", "100", "--json", "number,state"], runner)
+    prs = _run(["gh", "pr", "list", "--repo", repo, "--state", "all", "--limit", "100", "--json", "number,state,mergeCommit"], runner)
+    if not isinstance(issues, list) or not isinstance(prs, list):
+        raise LedgerCliError("gh returned invalid JSON")
+    snapshot = {
+        "issues": {str(item["number"]): {"state": item["state"]} for item in issues},
+        "prs": {
+            str(item["number"]): {
+                "state": item["state"],
+                "merge_sha": (item.get("mergeCommit") or {}).get("oid"),
+            }
+            for item in prs
+        },
+        "branches": {},
+    }
+    for branch in branches:
+        ref = _run(["gh", "api", f"repos/{repo}/git/ref/heads/{branch}"], runner)
+        try:
+            snapshot["branches"][branch] = ref["object"]["sha"]
+        except (KeyError, TypeError):
+            raise LedgerCliError("gh returned invalid ref JSON") from None
+    return snapshot
+
+
+def main(argv=None, *, root=None, runner=subprocess.run):
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--repo", required=True)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 2
+    if not re.fullmatch(r"[^/\s]+/[^/\s]+", args.repo):
+        print("usage: --repo OWNER/REPO required")
+        return 2
+    root = Path(root or Path(__file__).parents[1])
+    try:
+        issue_dir = root / "docs" / "issues"
+        roadmap_text = (issue_dir / "README.md").read_text(encoding="utf-8")
+        inventory_text = (root / "docs" / "plans" / "branch-inventory.md").read_text(encoding="utf-8")
+        issue_texts = {path.name: path.read_text(encoding="utf-8") for path in issue_dir.glob("ISSUE-*.md")}
+        branches, _ = _inventory(inventory_text)
+        errors = validate_ledger(
+            roadmap_text=roadmap_text,
+            issue_texts=issue_texts,
+            inventory_text=inventory_text,
+            snapshot=collect_snapshot(args.repo, branches, runner),
+        )
+    except (OSError, UnicodeError, LedgerCliError):
+        print("ledger validator: expected readable documents and gh JSON, actual unavailable")
+        return 2
+    for error in errors:
+        print(error)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -32,9 +32,16 @@ def _obsolete(text):
 def _roadmap_rows(text):
     rows = {}
     for line in text.splitlines():
-        match = re.fullmatch(r"\|\s*#(\d+)\s*\|\s*([a-z-]+)\s*\|.*\|", line.strip())
-        if match:
-            rows[match.group(1)] = match.group(2)
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if not cells or not re.fullmatch(r"#\d+", cells[0]):
+            continue
+        number = cells[0][1:]
+        if len(cells) > 1 and cells[1] in {"queued", "planning", "active", "review", "blocked-awaiting-user", "closed"}:
+            rows[number] = cells[1]
+        elif len(cells) > 2:
+            status = re.match(r"\*{0,2}(Open|Closed)\b", cells[2], re.IGNORECASE)
+            if status:
+                rows.setdefault(number, status.group(1).lower())
     return rows
 
 

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -167,7 +167,7 @@ def collect_snapshot(repo, branches, runner=subprocess.run):
         normalized_issues = {
             str(item["number"]): {"state": item["state"]}
             for item in issues
-            if isinstance(item["number"], int) and item["number"] > 0 and item["state"] in {"OPEN", "CLOSED"}
+            if type(item["number"]) is int and item["number"] > 0 and item["state"] in {"OPEN", "CLOSED"}
         }
         normalized_prs = {
             str(item["number"]): {
@@ -175,7 +175,7 @@ def collect_snapshot(repo, branches, runner=subprocess.run):
                 "merge_sha": (item.get("mergeCommit") or {}).get("oid"),
             }
             for item in prs
-            if isinstance(item["number"], int)
+            if type(item["number"]) is int
             and item["number"] > 0
             and item["state"] in {"OPEN", "CLOSED", "MERGED"}
             and (item.get("mergeCommit") is None or isinstance(item.get("mergeCommit"), dict))

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -109,7 +109,7 @@ def validate_ledger(*, roadmap_text, issue_texts, inventory_text, snapshot):
         elif number not in issues:
             errors.append(f"issue #{number}: expected {_state(status)}, actual missing")
         elif issues[number].get("state") != _state(status):
-            errors.append(f"{label}: expected {_state(issues[number].get('state', 'missing'))}, actual {status}")
+            errors.append(f"{label}: expected {status}, actual {issues[number].get('state', 'missing')}")
         if _obsolete(text):
             errors.append(f"{label}: expected no obsolete activation wording, actual {OBSOLETE}")
 

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -151,22 +151,41 @@ def collect_snapshot(repo, branches, runner=subprocess.run):
     prs = _run(["gh", "pr", "list", "--repo", repo, "--state", "all", "--limit", "100", "--json", "number,state,mergeCommit"], runner)
     if not isinstance(issues, list) or not isinstance(prs, list):
         raise LedgerCliError("gh returned invalid JSON")
-    snapshot = {
-        "issues": {str(item["number"]): {"state": item["state"]} for item in issues},
-        "prs": {
+    try:
+        normalized_issues = {
+            str(item["number"]): {"state": item["state"]}
+            for item in issues
+            if isinstance(item["number"], int) and item["number"] > 0 and item["state"] in {"OPEN", "CLOSED"}
+        }
+        normalized_prs = {
             str(item["number"]): {
                 "state": item["state"],
                 "merge_sha": (item.get("mergeCommit") or {}).get("oid"),
             }
             for item in prs
-        },
+            if isinstance(item["number"], int)
+            and item["number"] > 0
+            and item["state"] in {"OPEN", "CLOSED", "MERGED"}
+            and (item.get("mergeCommit") is None or isinstance(item.get("mergeCommit"), dict))
+            and (item.get("mergeCommit") is None or isinstance(item["mergeCommit"].get("oid"), str))
+        }
+    except (KeyError, TypeError):
+        raise LedgerCliError("gh returned invalid JSON") from None
+    if len(normalized_issues) != len(issues) or len(normalized_prs) != len(prs):
+        raise LedgerCliError("gh returned invalid JSON")
+    snapshot = {
+        "issues": normalized_issues,
+        "prs": normalized_prs,
         "branches": {},
     }
     for branch in branches:
         ref = _run(["gh", "api", f"repos/{repo}/git/ref/heads/{branch}"], runner)
         try:
-            snapshot["branches"][branch] = ref["object"]["sha"]
-        except (KeyError, TypeError):
+            sha = ref["object"]["sha"]
+            if not isinstance(sha, str) or not re.fullmatch(SHA, sha):
+                raise ValueError
+            snapshot["branches"][branch] = sha
+        except (KeyError, TypeError, ValueError):
             raise LedgerCliError("gh returned invalid ref JSON") from None
     return snapshot
 

--- a/scripts/validate_issue_ledger.py
+++ b/scripts/validate_issue_ledger.py
@@ -16,6 +16,11 @@ class LedgerCliError(Exception):
     pass
 
 
+class SafeArgumentParser(argparse.ArgumentParser):
+    def error(self, _message):
+        raise ValueError
+
+
 def _state(value):
     return "CLOSED" if value.lower() == "closed" else "OPEN"
 
@@ -199,14 +204,15 @@ def collect_snapshot(repo, branches, runner=subprocess.run):
 
 
 def main(argv=None, *, root=None, runner=subprocess.run):
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = SafeArgumentParser(add_help=False)
     parser.add_argument("--repo", required=True)
     try:
         args = parser.parse_args(argv)
-    except SystemExit:
+    except (SystemExit, ValueError):
+        print("usage: python scripts/validate_issue_ledger.py --repo OWNER/REPO")
         return 2
     if not re.fullmatch(r"[^/\s]+/[^/\s]+", args.repo):
-        print("usage: --repo OWNER/REPO required")
+        print("usage: python scripts/validate_issue_ledger.py --repo OWNER/REPO")
         return 2
     root = Path(root or Path(__file__).parents[1])
     try:

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -154,6 +154,20 @@ def test_malformed_required_canonical_data_is_a_mismatch():
     assert "ISSUE-015: expected documented Status, actual malformed" in errors
 
 
+def test_established_canonical_open_status_forms_validate_against_live_state():
+    live = snapshot()
+    live["issues"].update({"5": {"state": "OPEN"}, "17": {"state": "OPEN"}, "23": {"state": "OPEN"}})
+    errors = validate(
+        issue_texts={
+            "ISSUE-005-prompt-injection.md": "**Status:** OPEN\n",
+            "ISSUE-017-postgres-consolidation.md": "**Status:** Canonical epic; open.\n",
+            "ISSUE-023-retrieval-parity.md": "Status: **Open — migration gate**\n",
+        },
+        snapshot=live,
+    )
+    assert errors == []
+
+
 def test_bad_usage_returns_2(capsys):
     assert ledger_module().main(["--repo", "not-a-repository"]) == 2
     assert "not-a-repository" not in capsys.readouterr().out

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -1,0 +1,179 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "validate_issue_ledger.py"
+SHA_MAIN = "a" * 40
+SHA_MERGE = "b" * 40
+
+
+def ledger_module():
+    spec = importlib.util.spec_from_file_location("validate_issue_ledger", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def roadmap(active="#37"):
+    state_37 = "active" if active == "#37" else "queued"
+    active_row = active if active != "none" else "none"
+    return "\n".join(
+        (
+            "## Current JIT state",
+            "| Issue | State | Packet / next gate |",
+            "|---|---|---|",
+            f"| #37 | {state_37} | Ledger synchronization |",
+            "| #38 | queued | Streamlit evidence contract |",
+            f"| Active issue | {active_row} | declared sole active issue |",
+        )
+    )
+
+
+def issue_15(status="CLOSED", extra=""):
+    return f"# Issue #15: Atomically write vault JSON\n\n**Status:** {status} — completed.\n{extra}\n"
+
+
+def inventory(branch_sha=SHA_MAIN, pr36_sha=SHA_MERGE, pr1_state="CLOSED, unmerged"):
+    return "\n".join(
+        (
+            "## `main`",
+            f"- Execution gate tip: `{branch_sha}`",
+            "",
+            "## PR #1 — GUI",
+            f"- State at inspection: **{pr1_state}**.",
+            "",
+            "## PR #36 — Atomic vault write",
+            "- State at inspection: **MERGED**.",
+            f"- GitHub Create-a-merge-commit SHA: `{pr36_sha}`.",
+        )
+    )
+
+
+def snapshot(*, issue_37="OPEN", issue_38="OPEN", issue_15="CLOSED", pr36_sha=SHA_MERGE, pr1_state="CLOSED", pr1_sha=None, branch_sha=SHA_MAIN):
+    return {
+        "issues": {
+            "37": {"state": issue_37},
+            "38": {"state": issue_38},
+            "15": {"state": issue_15},
+        },
+        "prs": {
+            "1": {"state": pr1_state, "merge_sha": pr1_sha},
+            "36": {"state": "MERGED", "merge_sha": pr36_sha},
+        },
+        "branches": {"main": branch_sha},
+    }
+
+
+def validate(**changes):
+    module = ledger_module()
+    values = {
+        "roadmap_text": roadmap(),
+        "issue_texts": {"ISSUE-015-atomic-vault-write.md": issue_15()},
+        "inventory_text": inventory(),
+        "snapshot": snapshot(),
+    }
+    values.update(changes)
+    return module.validate_ledger(**values)
+
+
+def test_reconciled_activated_sole_active_ledger_passes():
+    assert validate() == []
+
+
+def test_reconciled_zero_active_ledger_passes():
+    assert validate(roadmap_text=roadmap("none")) == []
+
+
+def test_stale_tracked_issue_row_reports_expected_and_actual_state():
+    errors = validate(snapshot=snapshot(issue_37="CLOSED"))
+    assert "issue #37: expected OPEN, actual CLOSED" in errors
+
+
+def test_stale_canonical_issue_status_and_lifecycle_phrase_are_mismatches():
+    errors = validate(
+        issue_texts={"ISSUE-015-atomic-vault-write.md": issue_15("ACTIVE", "future activation merge")}
+    )
+    assert "ISSUE-015: expected CLOSED, actual ACTIVE" in errors
+    assert "ISSUE-015: expected no obsolete activation wording, actual future activation merge" in errors
+
+
+def test_stale_merged_pr_sha_is_a_mismatch():
+    errors = validate(snapshot=snapshot(pr36_sha="c" * 40))
+    assert f"PR #36 merge SHA: expected {SHA_MERGE}, actual {'c' * 40}" in errors
+
+
+def test_closed_unmerged_pr_disposition_requires_no_merge_sha():
+    errors = validate(snapshot=snapshot(pr1_sha="d" * 40))
+    assert f"PR #1 merge SHA: expected none, actual {'d' * 40}" in errors
+
+
+def test_stale_execution_gate_branch_tip_is_a_mismatch():
+    errors = validate(snapshot=snapshot(branch_sha="e" * 40))
+    assert f"branch main: expected {SHA_MAIN}, actual {'e' * 40}" in errors
+
+
+def test_duplicate_active_issues_are_a_mismatch():
+    duplicate = roadmap().replace("| #38 | queued |", "| #38 | active |")
+    errors = validate(roadmap_text=duplicate)
+    assert "active issues: expected at most one, actual #37, #38" in errors
+
+
+def test_missing_37_or_38_is_a_mismatch():
+    errors = validate(roadmap_text=roadmap().replace("| #38 | queued | Streamlit evidence contract |\n", ""))
+    assert "roadmap #38: expected present, actual missing" in errors
+
+
+def test_obsolete_activation_wording_in_roadmap_is_a_mismatch():
+    errors = validate(roadmap_text=roadmap() + "\nfuture activation merge\n")
+    assert "roadmap: expected no obsolete activation wording, actual future activation merge" in errors
+
+
+def test_malformed_required_canonical_data_is_a_mismatch():
+    errors = validate(issue_texts={"ISSUE-015-atomic-vault-write.md": "# Issue #15\n"})
+    assert "ISSUE-015: expected documented Status, actual malformed" in errors
+
+
+def test_bad_usage_returns_2():
+    assert ledger_module().main(["--repo", "not-a-repository"]) == 2
+
+
+def test_gh_and_api_failures_return_2(tmp_path):
+    root = tmp_path
+    (root / "docs" / "issues").mkdir(parents=True)
+    (root / "docs" / "plans").mkdir()
+    (root / "docs" / "issues" / "README.md").write_text(roadmap(), encoding="utf-8")
+    (root / "docs" / "issues" / "ISSUE-015-atomic-vault-write.md").write_text(issue_15(), encoding="utf-8")
+    (root / "docs" / "plans" / "branch-inventory.md").write_text(inventory(), encoding="utf-8")
+
+    def broken_runner(*_args, **_kwargs):
+        return subprocess.CompletedProcess([], 1, "", "authentication failed")
+
+    assert ledger_module().main(["--repo", "owner/repo"], root=root, runner=broken_runner) == 2
+
+
+def test_live_collector_uses_only_the_locked_gh_queries():
+    calls = []
+    responses = iter(
+        (
+            [{"number": 15, "state": "CLOSED"}, {"number": 37, "state": "OPEN"}, {"number": 38, "state": "OPEN"}],
+            [
+                {"number": 1, "state": "CLOSED", "mergeCommit": None},
+                {"number": 36, "state": "MERGED", "mergeCommit": {"oid": SHA_MERGE}},
+            ],
+            {"object": {"sha": SHA_MAIN}},
+        )
+    )
+
+    def runner(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, json.dumps(next(responses)), "")
+
+    actual = ledger_module().collect_snapshot("owner/repo", {"main": SHA_MAIN}, runner)
+    assert actual == snapshot()
+    assert calls == [
+        ["gh", "issue", "list", "--repo", "owner/repo", "--state", "all", "--limit", "100", "--json", "number,state"],
+        ["gh", "pr", "list", "--repo", "owner/repo", "--state", "all", "--limit", "100", "--json", "number,state,mergeCommit"],
+        ["gh", "api", "repos/owner/repo/git/ref/heads/main"],
+    ]

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -252,3 +252,29 @@ def test_zero_exit_malformed_gh_payloads_return_2_without_a_traceback(tmp_path, 
 
         assert ledger_module().main(["--repo", "owner/repo"], root=root, runner=runner) == 2
         assert "Traceback" not in capsys.readouterr().out
+
+
+def test_real_canonical_corpus_exposes_only_issue_009_lifecycle_drift():
+    root = Path(__file__).parents[1]
+    issue_dir = root / "docs" / "issues"
+    expected_states = {
+        "2": "OPEN", "5": "OPEN", "6": "CLOSED", "7": "OPEN", "8": "CLOSED", "9": "CLOSED",
+        "10": "OPEN", "11": "OPEN", "12": "OPEN", "13": "OPEN", "14": "CLOSED", "15": "CLOSED",
+        "16": "OPEN", "17": "OPEN", "18": "OPEN", "19": "OPEN", "20": "OPEN", "21": "OPEN",
+        "22": "OPEN", "23": "OPEN", "24": "OPEN", "25": "OPEN", "26": "OPEN", "27": "OPEN",
+        "37": "OPEN", "38": "OPEN",
+    }
+    errors = ledger_module().validate_ledger(
+        roadmap_text=(issue_dir / "README.md").read_text(encoding="utf-8"),
+        issue_texts={path.name: path.read_text(encoding="utf-8") for path in issue_dir.glob("ISSUE-*.md")},
+        inventory_text=(root / "docs" / "plans" / "branch-inventory.md").read_text(encoding="utf-8"),
+        snapshot={
+            "issues": {number: {"state": state} for number, state in expected_states.items()},
+            "prs": {
+                "1": {"state": "CLOSED", "merge_sha": None},
+                "36": {"state": "MERGED", "merge_sha": "88d0758ce1ffe6d61dd3ed99c0c5558e1bb8f205"},
+            },
+            "branches": {},
+        },
+    )
+    assert errors == []

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -154,8 +154,17 @@ def test_malformed_required_canonical_data_is_a_mismatch():
     assert "ISSUE-015: expected documented Status, actual malformed" in errors
 
 
-def test_bad_usage_returns_2():
+def test_bad_usage_returns_2(capsys):
     assert ledger_module().main(["--repo", "not-a-repository"]) == 2
+    assert "not-a-repository" not in capsys.readouterr().out
+
+
+def test_unknown_usage_argument_does_not_echo_credential_like_input(capsys):
+    assert ledger_module().main(["--secret", "ghp_not_for_output"]) == 2
+    output = capsys.readouterr()
+    assert "ghp_not_for_output" not in output.out + output.err
+    assert output.out == "usage: python scripts/validate_issue_ledger.py --repo OWNER/REPO\n"
+    assert output.err == ""
 
 
 def test_gh_and_api_failures_return_2(tmp_path):

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -130,6 +130,12 @@ def test_obsolete_activation_wording_in_roadmap_is_a_mismatch():
     assert "roadmap: expected no obsolete activation wording, actual future activation merge" in errors
 
 
+def test_stale_phrase_after_an_allowed_explanation_is_still_a_mismatch():
+    text = roadmap() + "\nknown stale lifecycle phrases include future activation merge\nfuture activation merge\n"
+    errors = validate(roadmap_text=text)
+    assert "roadmap: expected no obsolete activation wording, actual future activation merge" in errors
+
+
 def test_malformed_required_canonical_data_is_a_mismatch():
     errors = validate(issue_texts={"ISSUE-015-atomic-vault-write.md": "# Issue #15\n"})
     assert "ISSUE-015: expected documented Status, actual malformed" in errors

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -216,7 +216,13 @@ def test_zero_exit_malformed_gh_payloads_return_2_without_a_traceback(tmp_path, 
     (root / "docs" / "plans" / "branch-inventory.md").write_text(inventory(), encoding="utf-8")
     payloads = (
         ([{}], []),
+        ([{"number": True, "state": "OPEN"}], [], {"object": {"sha": SHA_MAIN}}),
         ([{"number": 15, "state": "CLOSED"}], [{}]),
+        (
+            [{"number": 15, "state": "CLOSED"}],
+            [{"number": True, "state": "OPEN", "mergeCommit": None}],
+            {"object": {"sha": SHA_MAIN}},
+        ),
         (
             [{"number": 15, "state": "CLOSED"}],
             [{"number": 1, "state": "CLOSED", "mergeCommit": None}],

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -177,3 +177,30 @@ def test_live_collector_uses_only_the_locked_gh_queries():
         ["gh", "pr", "list", "--repo", "owner/repo", "--state", "all", "--limit", "100", "--json", "number,state,mergeCommit"],
         ["gh", "api", "repos/owner/repo/git/ref/heads/main"],
     ]
+
+
+def test_zero_exit_malformed_gh_payloads_return_2_without_a_traceback(tmp_path, capsys):
+    root = tmp_path
+    (root / "docs" / "issues").mkdir(parents=True)
+    (root / "docs" / "plans").mkdir()
+    (root / "docs" / "issues" / "README.md").write_text(roadmap(), encoding="utf-8")
+    (root / "docs" / "issues" / "ISSUE-015-atomic-vault-write.md").write_text(issue_15(), encoding="utf-8")
+    (root / "docs" / "plans" / "branch-inventory.md").write_text(inventory(), encoding="utf-8")
+    payloads = (
+        ([{}], []),
+        ([{"number": 15, "state": "CLOSED"}], [{}]),
+        (
+            [{"number": 15, "state": "CLOSED"}],
+            [{"number": 1, "state": "CLOSED", "mergeCommit": None}],
+            {"object": {}},
+        ),
+    )
+
+    for responses in payloads:
+        response_iter = iter(responses)
+
+        def runner(command, **_kwargs):
+            return subprocess.CompletedProcess(command, 0, json.dumps(next(response_iter)), "")
+
+        assert ledger_module().main(["--repo", "owner/repo"], root=root, runner=runner) == 2
+        assert "Traceback" not in capsys.readouterr().out

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -95,7 +95,7 @@ def test_stale_canonical_issue_status_and_lifecycle_phrase_are_mismatches():
     errors = validate(
         issue_texts={"ISSUE-015-atomic-vault-write.md": issue_15("ACTIVE", "future activation merge")}
     )
-    assert "ISSUE-015: expected CLOSED, actual ACTIVE" in errors
+    assert "ISSUE-015: expected ACTIVE, actual CLOSED" in errors
     assert "ISSUE-015: expected no obsolete activation wording, actual future activation merge" in errors
 
 

--- a/tests/test_validate_issue_ledger.py
+++ b/tests/test_validate_issue_ledger.py
@@ -91,6 +91,19 @@ def test_stale_tracked_issue_row_reports_expected_and_actual_state():
     assert "issue #37: expected OPEN, actual CLOSED" in errors
 
 
+def test_tracked_issues_table_validates_priority_type_rows():
+    tracked = "\n".join(
+        (
+            "## Tracked issues",
+            "| Issue | Priority and type | Status | Canonical plan |",
+            "|---|---|---|---|",
+            "| #15 | P0 bug | **Closed — completed** | Atomic vault write |",
+        )
+    )
+    errors = validate(roadmap_text=roadmap() + "\n" + tracked, issue_texts={}, snapshot=snapshot(issue_15="OPEN"))
+    assert "issue #15: expected CLOSED, actual OPEN" in errors
+
+
 def test_stale_canonical_issue_status_and_lifecycle_phrase_are_mismatches():
     errors = validate(
         issue_texts={"ISSUE-015-atomic-vault-write.md": issue_15("ACTIVE", "future activation merge")}


### PR DESCRIPTION
## Summary
- add the stdlib + existing `gh` canonical issue-ledger validator
- add deterministic and real-corpus regression coverage
- document mandatory lifecycle ownership/validation in `AGENTS.md`
- reconcile stale canonical #9 status exposed by the real-corpus gate

## Preserved history
- RED: `9894a6f` — `test(#37): specify issue ledger validation`
- GREEN: `2a3e60f` — `fix(#37): validate canonical issue ledger`
- accepted review/verifier fixes remain separate through exact head `ef0d4d48b022b013e9dce75d9aaf62f0ddf3bf71`

## Verification
- GSD code review: approved exact final head
- independent verifier: PASS exact final head
- focused/full: 20 passed
- py_compile: PASS
- git diff --check: PASS
- live `python scripts/validate_issue_ledger.py --repo sriharshaguthikonda/easy-local-rag`: exit 0, no output
- approved final scope: four tracked files

Closes #37 only after merge evidence and the separate closure-ledger PR.